### PR TITLE
Improve exception for orders with aborted payment state

### DIFF
--- a/src/Exception/ResponseWithAbortedPaymentStateException.php
+++ b/src/Exception/ResponseWithAbortedPaymentStateException.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\Exception;
 
-class ResponseWithAbortedPaymentStateException extends AbstractEcommerceException
+class ResponseWithAbortedPaymentStateException extends UnsupportedException
 {
     protected ?string $paymentState;
 

--- a/src/Exception/ResponseWithAbortedPaymentStateException.php
+++ b/src/Exception/ResponseWithAbortedPaymentStateException.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\EcommerceFrameworkBundle\Exception;
+
+class ResponseWithAbortedPaymentStateException extends AbstractEcommerceException
+{
+    protected ?string $paymentState;
+
+    public function __construct(?string $newPaymentState)
+    {
+        $message = 'Got response although payment state was already aborted, new payment state was ' . $newPaymentState;
+        parent::__construct($message);
+        $this->paymentState = $newPaymentState;
+    }
+
+    public function getPaymentState(): ?string
+    {
+        return $this->paymentState;
+    }
+}

--- a/src/OrderManager/V7/OrderAgent.php
+++ b/src/OrderManager/V7/OrderAgent.php
@@ -22,6 +22,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\EnvironmentInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Event\Model\OrderAgentEvent;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Event\OrderAgentEvents;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Exception\PaymentNotAllowedException;
+use Pimcore\Bundle\EcommerceFrameworkBundle\Exception\ResponseWithAbortedPaymentStateException;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Exception\UnsupportedException;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractOrder;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractOrderItem;
@@ -526,6 +527,7 @@ class OrderAgent implements OrderAgentInterface
      *
      * @throws Exception
      * @throws UnsupportedException
+     * @throws ResponseWithAbortedPaymentStateException
      */
     public function updatePayment(StatusInterface $status): static
     {
@@ -611,7 +613,7 @@ class OrderAgent implements OrderAgentInterface
             );
             $order->save(['versionNote' => 'OrderAgent::updatePayment - aborted response received.']);
 
-            throw new UnsupportedException('Got response although payment state was already aborted, new payment state was ' . $paymentStateBackup);
+            throw new ResponseWithAbortedPaymentStateException($paymentStateBackup);
         } elseif ($currentOrderFingerPrint != $status->getInternalPaymentId()) {
             // check, if order finger print has changed since start payment - if so, throw exception because something wired is going on
             // but finish update order first in order to have logging information


### PR DESCRIPTION
With this change, a developer can react to different state updates from the API.

In our case, we see it as a critical error, when the new state is considered successful but was already aborted. Otherwise, we just log it normally.

What do you think?

