### PR TITLE
Update AbstractConfig.php

### DIFF
--- a/src/IndexService/Config/AbstractConfig.php
+++ b/src/IndexService/Config/AbstractConfig.php
@@ -34,7 +34,7 @@ abstract class AbstractConfig implements ConfigInterface
 
     protected array $attributes = [];
 
-    protected array $searchAttributes;
+    protected array $searchAttributes = [];
 
     protected array $filterTypes;
 

--- a/src/VoucherService/TokenManager/Pattern.php
+++ b/src/VoucherService/TokenManager/Pattern.php
@@ -451,8 +451,8 @@ class Pattern extends AbstractTokenManager implements ExportableTokenManagerInte
                 if ($this->tokenExists($checkTokens, $insertCheckTokens)) {
                     $checkTokenCount--;
                     unset($checkTokens[$token]);
-                // Check if the length of the checkTokens Array matches the defined step range
-                // so the the checkTokens get matched against the database.
+                    // Check if the length of the checkTokens Array matches the defined step range
+                    // so the the checkTokens get matched against the database.
                 } elseif ($checkTokenCount == $tokenCheckStep) {
                     // Check if any of the tokens in the temporary array checkTokens already exists,
                     // if not so, merge the checkTokens array with the array of tokens to insert and


### PR DESCRIPTION
Typed property Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\AbstractConfig::$searchAttributes must not be accessed before initialization