### PR TITLE
Fix tokenizer config in example

### DIFF
--- a/doc/05_Index_Service/01_Product_Index_Configuration/07_Elastic_Search/01_Configuration_Details.md
+++ b/doc/05_Index_Service/01_Product_Index_Configuration/07_Elastic_Search/01_Configuration_Details.md
@@ -68,7 +68,7 @@ pimcore_ecommerce_framework:
                                       - allow_list_filter
                             tokenizer:
                                 my_ngram_tokenizer:
-                                    type: nGram
+                                    type: ngram
                                     min_gram: 2
                                     max_gram: 15
                                     token_chars: [letter, digit]


### PR DESCRIPTION
The camel cased `nGram` tokenizer is not allowed any more in Elasticsearch 8.x. Instead the lowercase `ngram` must be used.

See:
https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-8.0.html#nGram-edgeNGram-tokenizer-dreprecation