### PR TITLE
fix: Environment::setCurrentCheckoutTenant() compares wrong variable

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -237,7 +237,7 @@ class Environment implements EnvironmentInterface
     {
         $this->load();
 
-        if ($this->currentCheckoutTenant != $tenant) {
+        if ($this->currentTransientCheckoutTenant != $tenant) {
             if ($persistent) {
                 $this->currentCheckoutTenant = $tenant;
             }


### PR DESCRIPTION
`Environment::setCurrentCheckoutTenant()` should compare the variable it always adjusts in order to detect changes and not the one that is only conditionally adjusted.