### PR TITLE
Add admin order note user check

### DIFF
--- a/src/Controller/AdminOrderController.php
+++ b/src/Controller/AdminOrderController.php
@@ -329,7 +329,7 @@ class AdminOrderController extends UserAwareController implements KernelControll
             $quantity = null;
 
             // get avatar
-            $user = User::getById($note->getUser());
+            $user = $note->getUser() ? User::getById($note->getUser()) : null;
             $avatar = $user ? sprintf('/admin/user/get-image?id=%d', $user->getId()) : null;
 
             // group events


### PR DESCRIPTION
Currently an error occurs when the user in the note object is empty.

Pimcore\Model\User\AbstractUser::getById(): Argument #1 ($id) must be of type int, null given, called in /app/vendor/pimcore/ecommerce-framework-bundle/src/Controller/AdminOrderController.php on line 332