### PR TITLE
Add admin order note user check

### DIFF
--- a/src/Controller/AdminOrderController.php
+++ b/src/Controller/AdminOrderController.php
@@ -329,7 +329,7 @@ class AdminOrderController extends UserAwareController implements KernelControll
             $quantity = null;
 
             // get avatar
-            $user = User::getById($note->getUser());
+            $user = $note->getUser() ? User::getById($note->getUser()) : null;
             $avatar = $user ? sprintf('/admin/user/get-image?id=%d', $user->getId()) : null;
 
             // group events

--- a/src/VoucherService/TokenManager/Pattern.php
+++ b/src/VoucherService/TokenManager/Pattern.php
@@ -451,8 +451,8 @@ class Pattern extends AbstractTokenManager implements ExportableTokenManagerInte
                 if ($this->tokenExists($checkTokens, $insertCheckTokens)) {
                     $checkTokenCount--;
                     unset($checkTokens[$token]);
-                // Check if the length of the checkTokens Array matches the defined step range
-                // so the the checkTokens get matched against the database.
+                    // Check if the length of the checkTokens Array matches the defined step range
+                    // so the the checkTokens get matched against the database.
                 } elseif ($checkTokenCount == $tokenCheckStep) {
                     // Check if any of the tokens in the temporary array checkTokens already exists,
                     // if not so, merge the checkTokens array with the array of tokens to insert and


### PR DESCRIPTION
Currently an error occurs when the user in the note object is empty.

Pimcore\Model\User\AbstractUser::getById(): Argument https://github.com/pimcore/ecommerce-framework-bundle/issues/1 ($id) must be of type int, null given, called in /app/vendor/pimcore/ecommerce-framework-bundle/src/Controller/AdminOrderController.php on line 332