### PR TITLE
Gracefully handle non-existing tokens in voucher token condition

### DIFF
--- a/src/PricingManager/Condition/VoucherToken.php
+++ b/src/PricingManager/Condition/VoucherToken.php
@@ -59,7 +59,7 @@ class VoucherToken implements ConditionInterface
 
     public function checkVoucherCode(string $code): bool
     {
-        if (in_array(VoucherServiceToken::getByCode($code)->getVoucherSeriesId(), $this->allowListIds)) {
+        if (in_array(VoucherServiceToken::getByCode($code)?->getVoucherSeriesId(), $this->allowListIds)) {
             return true;
         }
 

--- a/src/PricingManager/Condition/VoucherToken.php
+++ b/src/PricingManager/Condition/VoucherToken.php
@@ -59,11 +59,7 @@ class VoucherToken implements ConditionInterface
 
     public function checkVoucherCode(string $code): bool
     {
-        if (in_array(VoucherServiceToken::getByCode($code)?->getVoucherSeriesId(), $this->allowListIds)) {
-            return true;
-        }
-
-        return false;
+        return in_array(VoucherServiceToken::getByCode($code)?->getVoucherSeriesId(), $this->allowListIds);
     }
 
     public function toJSON(): string


### PR DESCRIPTION
When the token does not exist, `VoucherServiceToken::getByCode()` will return `null`, which results in a `Call to a member function getVoucherSeriesId() on null` exception instead of returning a boolean in `checkVoucherCode()`.