### PR TITLE
Fix incorrect links to source code in docs

### DIFF
--- a/doc/03_Installation.md
+++ b/doc/03_Installation.md
@@ -67,7 +67,7 @@ There are two ways of preparing a Pimcore class for product-usage in the E-Comme
 the parent class functionality or the overriding models functionality of Pimcore 
 (see also [Overriding Models](https://github.com/pimcore/pimcore/tree/11.x/doc/20_Extending_Pimcore/03_Overriding_Models.md)).
 
-> If using the abstract class, also have a look at its [implementation](https://github.com/pimcore/pimcore/blob/11.x/bundles/EcommerceFrameworkBundle/Model/AbstractProduct.php). 
+> If using the abstract class, also have a look at its [implementation](https://github.com/pimcore/ecommerce-framework-bundle/tree/1.x/src/Model/AbstractProduct.php). 
 You might need to override a few methods that cannot be implemented by the abstract class and throw an 
 exception depending on the use case you are using it. 
 

--- a/doc/04_Configuration/README.md
+++ b/doc/04_Configuration/README.md
@@ -81,7 +81,7 @@ completely free how to merge common configuration entries.
 
 When configuring tenant specific services, there are multiple configuration entries demanding a service ID as configuration
 value. This means, the system expects the configured value to be available as service definition on the container. You can
-read through the service definitions defined in [PimcoreEcommerceFrameworkBundle](https://github.com/pimcore/pimcore/tree/11.x/bundles/EcommerceFrameworkBundle/config)
+read through the service definitions defined in [PimcoreEcommerceFrameworkBundle](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/Resources/config)
 to get an insight of default e-commerce services.
 
 As an example let's take a look at a price system configuration:
@@ -134,7 +134,7 @@ service ID as *template* to configure 2 independent child services by utilizing 
 
 This means, that when you request the `Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager\OrderManager` service from the
 container, it would be neither the default nor the b2b tenant. In fact, getting that service directly wouldn't work anyways
-as it is missing dependencies. If you take a look at the [service definition](https://github.com/pimcore/pimcore/tree/11.x/pimcore/lib/Pimcore/Bundle/EcommerceFrameworkBundle/Resources/config/order_manager.yaml)
+as it is missing dependencies. If you take a look at the [service definition](https://github.com/pimcore/ecommerce-framework-bundle/tree/1.x/src/Resources/config/order_manager.yaml)
 you can see that the definition is missing the `OrderAgentFactoryInterface` argument which will be resolved and set for each
 tenant specific order manager.
 

--- a/doc/05_Index_Service/01_Product_Index_Configuration/03_Assortment_Tenant_Configuration.md
+++ b/doc/05_Index_Service/01_Product_Index_Configuration/03_Assortment_Tenant_Configuration.md
@@ -22,7 +22,7 @@ For setting up an Assortment Tenant, following steps are necessary:
 - **Implementation of a Tenant Config:**
 The Tenant Config class is the central configuration of an assortment tenant, defines which products are available for 
 the tenant and provides the connection to the used *Product Index* implementation. It needs to implement 
-[`Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\ConfigInterface`](https://github.com/pimcore/pimcore/blob/11.x/bundles/EcommerceFrameworkBundle/IndexService/Config/ConfigInterface.php). 
+[`Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\ConfigInterface`](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/IndexService/Config/ConfigInterface.php). 
 For detailed information see in-source documentation of the interface. Following implementations are provided by the framework 
 and may be extended:
    - `Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\DefaultMysql`: Provides a simple mysql implementation of 
@@ -49,7 +49,7 @@ services:
 
 
 ### Setting current Assortment Tenant for Frontend
-The [E-Commerce Framework Environment](https://github.com/pimcore/pimcore/blob/11.x/bundles/EcommerceFrameworkBundle/EnvironmentInterface.php#L22-L22) 
+The [E-Commerce Framework Environment](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/EnvironmentInterface.php#L22-L22) 
 provides following methods to set the current Assortment Tenant when working with *Product Lists* in Code: 
 ```php
 <?php
@@ -110,7 +110,7 @@ assortment tenant.
 ### Implementing an Assortment Subtenant for MySQL
 The mapping which product is assigned to with subtenant is done with an additional mapping table. The necessary 
 joins and conditions are implemented within additional methods within 
-[`Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\MysqlConfigInterface`](https://github.com/pimcore/pimcore/blob/11.x/bundles/EcommerceFrameworkBundle/IndexService/Config/MysqlConfigInterface.php): 
+[`Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\MysqlConfigInterface`](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/IndexService/Config/MysqlConfigInterface.php): 
  
 ```php
     /**
@@ -160,7 +160,7 @@ In order to populate the additional mapping data, also following methods have to
     public function updateSubTenantEntries($objectId, $subTenantData, $subObjectId = null);
 ```
 
-For an complete example have a look at the [sample implementation](https://github.com/pimcore/pimcore/blob/11.x/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultMysqlSubTenantConfig.php).
+For an complete example have a look at the [sample implementation](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/IndexService/Config/DefaultMysqlSubTenantConfig.php).
 
 
 ### Implementing an Assortment Subtenant for Elasticsearch
@@ -180,7 +180,7 @@ In order to populate the additional mapping data, the following method has to be
 
 ```
 
-For an complete example have a look at the [sample implementation](https://github.com/pimcore/pimcore/blob/11.x/bundles/EcommerceFrameworkBundle/IndexService/Config/DefaultElasticSearchSubTenantConfig.php).
+For an complete example have a look at the [sample implementation](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/IndexService/Config/DefaultElasticSearchSubTenantConfig.php).
 
 ---
 

--- a/doc/05_Index_Service/07_Product_List.md
+++ b/doc/05_Index_Service/07_Product_List.md
@@ -4,7 +4,7 @@
 The API for getting (and filtering, ...) products out of the *Product Index* are so called Product Lists. They all 
 implement the interface `\Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\ProductList\ProductListInterface` and need to be 
 Product Index implementation specific. Detailed method documentation is available in 
-[in-source documentation](https://github.com/pimcore/pimcore/blob/11.x/bundles/EcommerceFrameworkBundle/IndexService/ProductList/ProductListInterface.php). 
+[in-source documentation](../../src/IndexService/ProductList/ProductListInterface.php). 
 
 For how to get a Product List instance suitable for the current Product Index implementation and filter for products see 
 following code sample: 

--- a/doc/05_Index_Service/07_Product_List.md
+++ b/doc/05_Index_Service/07_Product_List.md
@@ -4,7 +4,7 @@
 The API for getting (and filtering, ...) products out of the *Product Index* are so called Product Lists. They all 
 implement the interface `\Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\ProductList\ProductListInterface` and need to be 
 Product Index implementation specific. Detailed method documentation is available in 
-[in-source documentation](../../src/IndexService/ProductList/ProductListInterface.php). 
+[in-source documentation](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/IndexService/ProductList/ProductListInterface.php). 
 
 For how to get a Product List instance suitable for the current Product Index implementation and filter for products see 
 following code sample: 

--- a/doc/07_Filter_Service/README.md
+++ b/doc/07_Filter_Service/README.md
@@ -28,7 +28,7 @@ Therefore `\Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\FilterType\Abs
 `getFilterValues()` and `addCondition()` to be implemented. 
 
 Each Filter Type needs to be defined as service and registered on the `pimcore_ecommerce_framework.filter_service` configuration.
-The framework already defines a number of core filter types in [filter_service_filter_types.yaml](https://github.com/pimcore/pimcore/blob/11.x/bundles/EcommerceFrameworkBundle/Resources/config/filter_service_filter_types.yaml).
+The framework already defines a number of core filter types in [filter_service_filter_types.yaml](../../src/Resources/config/filter_service_filter_types.yaml).
 
 > FilterTypes are dependent of the used index backend. You need to use different FilterTypes when using MySQL or ElasticSearch etc. 
 > Pimcore ships with FilterTypes implementations for all supported index backends. For details see for example 

--- a/doc/07_Filter_Service/README.md
+++ b/doc/07_Filter_Service/README.md
@@ -28,7 +28,7 @@ Therefore `\Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\FilterType\Abs
 `getFilterValues()` and `addCondition()` to be implemented. 
 
 Each Filter Type needs to be defined as service and registered on the `pimcore_ecommerce_framework.filter_service` configuration.
-The framework already defines a number of core filter types in [filter_service_filter_types.yaml](../../src/Resources/config/filter_service_filter_types.yaml).
+The framework already defines a number of core filter types in [filter_service_filter_types.yaml](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/Resources/config/filter_service_filter_types.yaml).
 
 > FilterTypes are dependent of the used index backend. You need to use different FilterTypes when using MySQL or ElasticSearch etc. 
 > Pimcore ships with FilterTypes implementations for all supported index backends. For details see for example 

--- a/doc/09_Working_with_Prices/01_Price_Systems_and_getting_Prices.md
+++ b/doc/09_Working_with_Prices/01_Price_Systems_and_getting_Prices.md
@@ -13,7 +13,7 @@ In terms of product availabilities and stocks, the very similar concept of Avail
 
 A price system is a class implementing `Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\PriceSystemInterface` which is defined
 as service and registered with a name in the `pimcore_ecommerce_framework.price_systems` configuration tree. The framework
-already ships with a number of [concrete implementations](https://github.com/pimcore/pimcore/tree/11.x/bundles/EcommerceFrameworkBundle/PriceSystem)
+already ships with a number of [concrete implementations](../../src/PriceSystem)
 which you can use as starting point.
 
 There are 3 places where the configuration of Price Systems takes place: 
@@ -81,9 +81,9 @@ pimcore_ecommerce_framework:
 
 ```
 
-> The simplest price system is [`Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\AttributePriceSystem`](https://github.com/pimcore/pimcore/blob/11.x/bundles/EcommerceFrameworkBundle/PriceSystem/AttributePriceSystem.php) 
+> The simplest price system is [`Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\AttributePriceSystem`](../../src/PriceSystem/AttributePriceSystem.php) 
 > which reads the price from an attribute of the product object. For implementing custom price systems have a look at method comments 
-> of [`\Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\PriceSystemInterface`](https://github.com/pimcore/pimcore/blob/11.x/bundles/EcommerceFrameworkBundle/PriceSystem/PriceSystemInterface.php) 
+> of [`\Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\PriceSystemInterface`](../../src/PriceSystem/PriceSystemInterface.php) 
 > and the implementations of the existing price systems. 
 
 

--- a/doc/09_Working_with_Prices/01_Price_Systems_and_getting_Prices.md
+++ b/doc/09_Working_with_Prices/01_Price_Systems_and_getting_Prices.md
@@ -13,7 +13,7 @@ In terms of product availabilities and stocks, the very similar concept of Avail
 
 A price system is a class implementing `Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\PriceSystemInterface` which is defined
 as service and registered with a name in the `pimcore_ecommerce_framework.price_systems` configuration tree. The framework
-already ships with a number of [concrete implementations](../../src/PriceSystem)
+already ships with a number of [concrete implementations](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/PriceSystem)
 which you can use as starting point.
 
 There are 3 places where the configuration of Price Systems takes place: 
@@ -81,9 +81,9 @@ pimcore_ecommerce_framework:
 
 ```
 
-> The simplest price system is [`Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\AttributePriceSystem`](../../src/PriceSystem/AttributePriceSystem.php) 
+> The simplest price system is [`Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\AttributePriceSystem`](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/PriceSystem/AttributePriceSystem.php) 
 > which reads the price from an attribute of the product object. For implementing custom price systems have a look at method comments 
-> of [`\Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\PriceSystemInterface`](../../src/PriceSystem/PriceSystemInterface.php) 
+> of [`\Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\PriceSystemInterface`](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/PriceSystem/PriceSystemInterface.php) 
 > and the implementations of the existing price systems. 
 
 

--- a/doc/09_Working_with_Prices/09_Calculate_with_Prices.md
+++ b/doc/09_Working_with_Prices/09_Calculate_with_Prices.md
@@ -7,7 +7,7 @@ value objects instead of floats to represent prices. These value objects interna
 by defining a fixed amount of supported digits (so-called `scale`) after the comma and by multiplying the actual value
 with the given scale on construction. The scale is set to 4 by default, but can be changed globally in the `pimcore_ecommerce_framework.decimal_scale`
 config entry.
-Decimal
+
 An example: Given a scale of 4, a `Decimal` will internally represent a number of `123.45` as `1234500` by calculating
 `123.45 * 10^4 = 1234500`. 
  
@@ -81,7 +81,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Type\Decimal;
 var_dump(Decimal::create('123.55555', 4, PHP_ROUND_HALF_DOWN)->asString()); // 123.5555
 var_dump(Decimal::create('123.55555', 4, PHP_ROUND_HALF_UP)->asString());   // 123.5556
 ```
-../../
+
 Please be aware that as rounding is applied only when exceeding the scale, the following can happen: 
 
 ```

--- a/doc/09_Working_with_Prices/09_Calculate_with_Prices.md
+++ b/doc/09_Working_with_Prices/09_Calculate_with_Prices.md
@@ -2,7 +2,7 @@
 
 As floating point numbers (`float`, `double`) are not able to represent numbers exactly (see [here](http://floating-point-gui.de/)
 if you want to know details), and exact numbers are a strict demand to e-commerce applications the E-Commerce Framrwork
-uses [`Decimal`](https://github.com/pimcore/pimcore/blob/11.x/bundles/EcommerceFrameworkBundle/Type/Decimal.php)
+uses [`Decimal`](https://github.com/pimcore/ecommerce-framework-bundle/tree/1.x/src/Type/Decimal.php)
 value objects instead of floats to represent prices. These value objects internally store the represented value as integer
 by defining a fixed amount of supported digits (so-called `scale`) after the comma and by multiplying the actual value
 with the given scale on construction. The scale is set to 4 by default, but can be changed globally in the `pimcore_ecommerce_framework.decimal_scale`
@@ -12,8 +12,8 @@ An example: Given a scale of 4, a `Decimal` will internally represent a number o
 `123.45 * 10^4 = 1234500`. 
  
 To calculate with these values, the `Decimal` class exposes methods like `add()`, `sub()`, `mul()`, `div()` and others
-to run calculations without having to deal with the internal scale representation. For details see the [Decimal class definition](../../src/Type/Decimal.php)
-and the corresponding [test](../../tests/Ecommerce/Type/DecimalTest.php)
+to run calculations without having to deal with the internal scale representation. For details see the [Decimal class definition](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/Type/Decimal.php)
+and the corresponding [test](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/tests/Ecommerce/Type/DecimalTest.php)
 which contains a lot of usage examples and describes the `Decimal` behaviour quite well.
 
 > **Important**: The `Decimal` is designed as *immutable* value object. Every operation yields a *new* instance of a `Decimal`
@@ -81,7 +81,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Type\Decimal;
 var_dump(Decimal::create('123.55555', 4, PHP_ROUND_HALF_DOWN)->asString()); // 123.5555
 var_dump(Decimal::create('123.55555', 4, PHP_ROUND_HALF_UP)->asString());   // 123.5556
 ```
-
+../../
 Please be aware that as rounding is applied only when exceeding the scale, the following can happen: 
 
 ```

--- a/doc/09_Working_with_Prices/09_Calculate_with_Prices.md
+++ b/doc/09_Working_with_Prices/09_Calculate_with_Prices.md
@@ -7,13 +7,13 @@ value objects instead of floats to represent prices. These value objects interna
 by defining a fixed amount of supported digits (so-called `scale`) after the comma and by multiplying the actual value
 with the given scale on construction. The scale is set to 4 by default, but can be changed globally in the `pimcore_ecommerce_framework.decimal_scale`
 config entry.
-
+Decimal
 An example: Given a scale of 4, a `Decimal` will internally represent a number of `123.45` as `1234500` by calculating
 `123.45 * 10^4 = 1234500`. 
  
 To calculate with these values, the `Decimal` class exposes methods like `add()`, `sub()`, `mul()`, `div()` and others
-to run calculations without having to deal with the internal scale representation. For details see the [Decimal class definition](https://github.com/pimcore/pimcore/blob/11.x/bundles/EcommerceFrameworkBundle/Type/Decimal.php)
-and the corresponding [test](https://github.com/pimcore/pimcore/blob/11.x/tests/ecommerce/Type/DecimalTest.php)
+to run calculations without having to deal with the internal scale representation. For details see the [Decimal class definition](../../src/Type/Decimal.php)
+and the corresponding [test](../../tests/Ecommerce/Type/DecimalTest.php)
 which contains a lot of usage examples and describes the `Decimal` behaviour quite well.
 
 > **Important**: The `Decimal` is designed as *immutable* value object. Every operation yields a *new* instance of a `Decimal`

--- a/doc/10_Working_with_Availabilities.md
+++ b/doc/10_Working_with_Availabilities.md
@@ -9,10 +9,10 @@ Each product can have its own Availability System.
 
 ## Configuration of Availability Systems
 
-A availability system is a class implementing `Pimcore\Bundle\EcommerceFrameworkBundle\AvailabilitySystem\AvailabilitySystemInterface` which 
+An availability system is a class implementing `Pimcore\Bundle\EcommerceFrameworkBundle\AvailabilitySystem\AvailabilitySystemInterface` which 
 is defined as service and registered with a name in the `pimcore_ecommerce_framework.availability_systems` configuration tree. 
 
-Currently the framework ships only with a [sample implementation](https://github.com/pimcore/pimcore/blob/11.x/bundles/EcommerceFrameworkBundle/AvailabilitySystem/AvailabilitySystem.php#L20)
+Currently, the framework ships only with a [sample implementation](../src/AvailabilitySystem/AvailabilitySystem.php#L20)
 which you can use as starting point.
 
 There are 3 places where the configuration of Availability Systems takes place: 

--- a/doc/10_Working_with_Availabilities.md
+++ b/doc/10_Working_with_Availabilities.md
@@ -12,7 +12,7 @@ Each product can have its own Availability System.
 An availability system is a class implementing `Pimcore\Bundle\EcommerceFrameworkBundle\AvailabilitySystem\AvailabilitySystemInterface` which 
 is defined as service and registered with a name in the `pimcore_ecommerce_framework.availability_systems` configuration tree. 
 
-Currently, the framework ships only with a [sample implementation](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/AvailabilitySystem/AvailabilitySystem.php#L20)
+Currently, the framework ships only with a [sample implementation](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/AvailabilitySystem/AvailabilitySystem.php#L21)
 which you can use as starting point.
 
 There are 3 places where the configuration of Availability Systems takes place: 

--- a/doc/10_Working_with_Availabilities.md
+++ b/doc/10_Working_with_Availabilities.md
@@ -12,7 +12,7 @@ Each product can have its own Availability System.
 An availability system is a class implementing `Pimcore\Bundle\EcommerceFrameworkBundle\AvailabilitySystem\AvailabilitySystemInterface` which 
 is defined as service and registered with a name in the `pimcore_ecommerce_framework.availability_systems` configuration tree. 
 
-Currently, the framework ships only with a [sample implementation](../src/AvailabilitySystem/AvailabilitySystem.php#L20)
+Currently, the framework ships only with a [sample implementation](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/AvailabilitySystem/AvailabilitySystem.php#L20)
 which you can use as starting point.
 
 There are 3 places where the configuration of Availability Systems takes place: 

--- a/doc/11_Cart_Manager.md
+++ b/doc/11_Cart_Manager.md
@@ -3,7 +3,7 @@
 The Cart Manager is responsible for all aspects concerning carts and can manage multiple carts. 
 Important to know is, that in the E-Commerce Framework every user specific product collection is a cart. No matter 
 how it is called (cart, wish list, compare list, ...), all these product collections need the same base 
-functionality. Therefore all different product collections are carts with a specific name.
+functionality. Therefore, all different product collections are carts with a specific name.
  
 
 ## Working with Carts
@@ -76,7 +76,7 @@ $subTotal = $cart->getPriceCalculator()->getSubTotal();
 // iterates through all price modifications
 foreach ($cart->getPriceCalculator()->getPriceModifications() as $name => $modification) {
     // $name is the label of a modification
-    // $modification is a OnlineShop_Framework_IModificatedPrice
+    // $modification is an implementation of \Pimcore\Bundle\EcommerceFrameworkBundle\PriceSystem\ModificatedPriceInterface
 }
  
 // delivers sum including all price modifications
@@ -132,9 +132,9 @@ Following elements are configured:
   by factory implementation
 * **Price calculator factory service ID + options and modificators**: The price calculator is a framework for calculation
   and modification (shipping costs, discounts, ...) of prices on cart level. Each modification is implemented in a 
-  [`CartPriceModificatorInterface` class](https://github.com/pimcore/pimcore/blob/11.x/bundles/EcommerceFrameworkBundle/CartManager/CartPriceModificator/CartPriceModificatorInterface.php). 
-  See [Shipping](https://github.com/pimcore/pimcore/blob/11.x/bundles/EcommerceFrameworkBundle/CartManager/CartPriceModificator/Shipping.php)
-  or [Discount](https://github.com/pimcore/pimcore/blob/11.x/bundles/EcommerceFrameworkBundle/CartManager/CartPriceModificator/Discount.php)
+  [`CartPriceModificatorInterface` class](../src/CartManager/CartPriceModificator/CartPriceModificatorInterface.php). 
+  See [Shipping](../src/CartManager/CartPriceModificator/Shipping.php)
+  or [Discount](../src/CartManager/CartPriceModificator/Discount.php)
   for examples.
 
 
@@ -151,7 +151,7 @@ Use this implementation when no user login is available and storing carts in the
 
 * **Database-Cart** (class name `Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart`): This cart implementation
 stores all cart information in the **database**. In this case, it is important that the currently logged in user is set 
-to the [E-Commerce Framework Environment](https://github.com/pimcore/pimcore/blob/11.x/bundles/EcommerceFrameworkBundle/EnvironmentInterface.php)
+to the [E-Commerce Framework Environment](../src/EnvironmentInterface.php)
 with the code snippet in the box below. 
 Use this implementation when user logins are available and the carts should be persisted beyond session lifetime. 
 

--- a/doc/11_Cart_Manager.md
+++ b/doc/11_Cart_Manager.md
@@ -132,9 +132,9 @@ Following elements are configured:
   by factory implementation
 * **Price calculator factory service ID + options and modificators**: The price calculator is a framework for calculation
   and modification (shipping costs, discounts, ...) of prices on cart level. Each modification is implemented in a 
-  [`CartPriceModificatorInterface` class](../src/CartManager/CartPriceModificator/CartPriceModificatorInterface.php). 
-  See [Shipping](../src/CartManager/CartPriceModificator/Shipping.php)
-  or [Discount](../src/CartManager/CartPriceModificator/Discount.php)
+  [`CartPriceModificatorInterface` class](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/CartManager/CartPriceModificator/CartPriceModificatorInterface.php). 
+  See [Shipping](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/CartManager/CartPriceModificator/Shipping.php)
+  or [Discount](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/CartManager/CartPriceModificator/Discount.php)
   for examples.
 
 
@@ -151,7 +151,7 @@ Use this implementation when no user login is available and storing carts in the
 
 * **Database-Cart** (class name `Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart`): This cart implementation
 stores all cart information in the **database**. In this case, it is important that the currently logged in user is set 
-to the [E-Commerce Framework Environment](../src/EnvironmentInterface.php)
+to the [E-Commerce Framework Environment](https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/EnvironmentInterface.php)
 with the code snippet in the box below. 
 Use this implementation when user logins are available and the carts should be persisted beyond session lifetime. 
 


### PR DESCRIPTION
As the ecommerce framework has been moved into a standalone bundle, some links in the documentation which are still pointing to the main pimcore repository are broken