### PR TITLE
Filterservice Filtertype Input: type fix $value for trim()

### DIFF
--- a/src/FilterService/FilterType/Input.php
+++ b/src/FilterService/FilterType/Input.php
@@ -40,13 +40,13 @@ class Input extends AbstractFilterType
         $field = $this->getField($filterDefinition);
         $preSelect = $this->getPreSelect($filterDefinition);
 
-        $value = $params[$field] ?? null;
+        $value = $params[$field] ?? '';
         $isReload = $params['is_reload'] ?? null;
 
         if ($value == AbstractFilterType::EMPTY_STRING) {
-            $value = null;
+            $value = '';
         } elseif (empty($value) && !$isReload) {
-            $value = $preSelect;
+            $value = $preSelect ?? '';
         }
 
         $value = trim($value);


### PR DESCRIPTION
**Filterservice Filtertype Input:** 

If filtertype InputField is present in Filterdefinition, following error is shwon:
![image](https://github.com/pimcore/ecommerce-framework-bundle/assets/23357021/f10eb8d5-8f7d-48cf-b5d6-94f6b79ebc7d)

Should be fixed with this pull request: type fix $value for trim() --> $value must not be null

