### PR TITLE
Fix LIMIT_UNLIMITED type issue

### DIFF
--- a/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -321,7 +321,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
     }
 
     /**
-     * Pass "unlimited" to do da Scroll Request
+     * Pass -1 to do da Scroll Request
      *
      * @param int $limit
      *
@@ -329,11 +329,11 @@ abstract class AbstractElasticSearch implements ProductListInterface
      */
     public function setLimit(int $limit): void
     {
-        if ($this->limit != $limit) {
+        if ($this->limit !== $limit) {
             $this->products = null;
         }
 
-        if ($limit == static::LIMIT_UNLIMITED) {
+        if ($limit === static::LIMIT_UNLIMITED) {
             $this->limit = 100;
             $this->doScrollRequest = true;
         } else {

--- a/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -28,7 +28,7 @@ use Pimcore\Bundle\EcommerceFrameworkBundle\Model\IndexableInterface;
 
 abstract class AbstractElasticSearch implements ProductListInterface
 {
-    const LIMIT_UNLIMITED = 'unlimited';
+    const LIMIT_UNLIMITED = -1;
 
     const INTEGER_MAX_VALUE = 2147483647;     // Elasticsearch Integer.MAX_VALUE is 2^31-1
 

--- a/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -321,7 +321,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
     }
 
     /**
-     * Pass -1 to do da Scroll Request
+     * Pass -1 to enable the unlimited scroll request
      *
      * @param int $limit
      *


### PR DESCRIPTION
This fixes a type issue with the \Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\ProductList\ElasticSearch\AbstractElasticSearch::LIMIT_UNLIMITED constant. 

The external setter for the limit only accepts integer values thus preventing the use of the elastic scroll api and limiting result sets to 10.000 (default configuration) or the value max_result_window.

I have read the CLA Document and I hereby sign the CLA

 

