### PR TITLE
Avoid exception on empty configration prefix

### DIFF
--- a/src/VoucherService/TokenManager/Pattern.php
+++ b/src/VoucherService/TokenManager/Pattern.php
@@ -257,7 +257,7 @@ class Pattern extends AbstractTokenManager implements ExportableTokenManagerInte
     {
         $separatorCount = $this->configuration->getSeparatorCount();
         $separator = $this->configuration->getSeparator();
-        $prefix = $this->configuration->getPrefix() ?? '';
+        $prefix = (string)$this->configuration->getPrefix();
         if (!empty($separator)) {
             if (!empty($prefix)) {
                 return strlen($prefix) + 1 + (int) floor($this->configuration->getLength() / $separatorCount) + $this->configuration->getLength();

--- a/src/VoucherService/TokenManager/Pattern.php
+++ b/src/VoucherService/TokenManager/Pattern.php
@@ -257,16 +257,16 @@ class Pattern extends AbstractTokenManager implements ExportableTokenManagerInte
     {
         $separatorCount = $this->configuration->getSeparatorCount();
         $separator = $this->configuration->getSeparator();
-        $prefix = $this->configuration->getPrefix();
+        $prefix = $this->configuration->getPrefix() ?? '';
         if (!empty($separator)) {
             if (!empty($prefix)) {
-                return strlen($this->configuration->getPrefix()) + 1 + (int) floor($this->configuration->getLength() / $separatorCount) + $this->configuration->getLength();
+                return strlen($prefix) + 1 + (int) floor($this->configuration->getLength() / $separatorCount) + $this->configuration->getLength();
             }
 
             return (int) floor($this->configuration->getLength() / $separatorCount) + $this->configuration->getLength();
         }
 
-        return strlen($this->configuration->getPrefix()) + $this->configuration->getLength();
+        return strlen($prefix) + $this->configuration->getLength();
     }
 
     /**


### PR DESCRIPTION
If no prefix is given for a voucher series of type "pattern", then currently an exception is thrown.
This PR generates voucher series with empty prefix correctly.