### PR TITLE
Add possibility to set custom properties to cart item

### DIFF
--- a/doc/11_Cart_Manager.md
+++ b/doc/11_Cart_Manager.md
@@ -184,6 +184,9 @@ See also [Demo](https://github.com/pimcore/demo/blob/11.x/config/ecommerce/base-
 
 Following steps are necessary to add additional custom properties to cart items: 
 
-1) Extend `CartItem` implementation and extend it with your custom property fields and getters/setters. 
-2) Extend `Cart` implementation and make use your custom `CartItem` implementation is used.
-3) Provide the custom properties as key-value pairs in `params` parameter in `addItem` and `updateItem` of `Cart` or `CartManager`. 
+1) Extend `Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem` implementation and add your custom properties including getters/setters. 
+2) Extend `Cart::getCartItemClassName` implementation and make sure your custom `CartItem` implementation gets returned.
+3) Provide the custom properties as key-value pairs in `$params` parameter in the following methods:
+   1) `Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\AbstractCart::addItem`
+   2) `Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\AbstractCart::updateItem`
+   3) `Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartManagerInterface::addToCart`

--- a/doc/11_Cart_Manager.md
+++ b/doc/11_Cart_Manager.md
@@ -178,3 +178,12 @@ Once set, the cart manager uses all specific settings of the currently active ch
 in the configuration (identified by tenant name).
 
 See also [Demo](https://github.com/pimcore/demo/blob/11.x/config/ecommerce/base-ecommerce.yaml#L197) for some examples.  
+
+
+## Adding Custom Properties to Cart Items
+
+Following steps are necessary to add additional custom properties to cart items: 
+
+1) Extend `CartItem` implementation and extend it with your custom property fields and getters/setters. 
+2) Extend `Cart` implementation and make use your custom `CartItem` implementation is used.
+3) Provide the custom properties as key-value pairs in `params` parameter in `addItem` and `updateItem` of `Cart` or `CartManager`. 

--- a/src/CartManager/AbstractCart.php
+++ b/src/CartManager/AbstractCart.php
@@ -158,7 +158,9 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
             $item->setSubItems($subItems);
         }
 
-        $item->setCustomProperties($params);
+        if (method_exists($item, 'setCustomProperties')) {
+            $item->setCustomProperties($params);
+        }
 
         $this->items[$itemKey] = $item;
 

--- a/src/CartManager/AbstractCart.php
+++ b/src/CartManager/AbstractCart.php
@@ -158,6 +158,10 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
             $item->setSubItems($subItems);
         }
 
+        if (!empty($params)) {
+            $item->setCustomProperties($params);
+        }
+
         $this->items[$itemKey] = $item;
 
         // trigger cart has been modified

--- a/src/CartManager/AbstractCart.php
+++ b/src/CartManager/AbstractCart.php
@@ -158,9 +158,7 @@ abstract class AbstractCart extends AbstractModel implements CartInterface
             $item->setSubItems($subItems);
         }
 
-        if (!empty($params)) {
-            $item->setCustomProperties($params);
-        }
+        $item->setCustomProperties($params);
 
         $this->items[$itemKey] = $item;
 

--- a/src/CartManager/AbstractCartItem.php
+++ b/src/CartManager/AbstractCartItem.php
@@ -298,4 +298,20 @@ abstract class AbstractCartItem extends \Pimcore\Model\AbstractModel implements 
     {
         $this->isLoading = $isLoading;
     }
+
+    /**
+     * Sets custom properties to CartItem when provided in AbstractCart::addItem
+     *
+     * @param array $params
+     * @return void
+     */
+    public function setCustomProperties(array $params): void
+    {
+        foreach ($params as $key => $value) {
+            $method = 'set' . ucfirst($key);
+            if (method_exists($this, $method)) {
+                $this->{$method}($value);
+            }
+        }
+    }
 }

--- a/src/CartManager/CartItemInterface.php
+++ b/src/CartManager/CartItemInterface.php
@@ -112,6 +112,4 @@ interface CartItemInterface
      * @return string
      */
     public function getName(): string;
-
-    public function setCustomProperties(array $params): void;
 }

--- a/src/CartManager/CartItemInterface.php
+++ b/src/CartManager/CartItemInterface.php
@@ -112,4 +112,6 @@ interface CartItemInterface
      * @return string
      */
     public function getName(): string;
+
+    public function setCustomProperties(array $params): void;
 }


### PR DESCRIPTION
## Overview

The suggested change would make it easier to extend `CartItem` class and provide the property in `Cart::addItem()` as `$params` afterwards.

## Extend CartItem

The `$params` parameter in `AbstractCart::addItem` is currently unused in this method, but the doc-block suggests that it's possible to add additional data.

In `src/CartManager/CartInterface.php`:

>    /**
     * @param CheckoutableInterface $product
     * @param int $count
     * @param string|null $itemKey
     * @param bool $replace replace if item with same key exists
     * **@param array $params optional additional item information**
     * @param AbstractSetProductEntry[] $subProducts
     * @param string|null $comment
     *
     * @return string $itemKey
     */
    public function addItem(CheckoutableInterface $product, int $count, string $itemKey = null, bool $replace = false, array $params = [], array $subProducts = [], string $comment = null): string;

---

Also see: 
* https://github.com/pimcore/pimcore/discussions/16249
* https://github.com/pimcore/ecommerce-framework-bundle/issues/98