### PR TITLE
[bugfix] Legacy data with null-values clash with the stronger typing

### DIFF
--- a/src/PricingManager/Rule.php
+++ b/src/PricingManager/Rule.php
@@ -120,7 +120,7 @@ class Rule extends AbstractModel implements RuleInterface
                         return $this;
                     }
             }
-            $this->$method($value);
+            $this->$method($value ?? '');
         }
 
         return $this;


### PR DESCRIPTION
Sometimes legacy data could trigger an exception because of null-values.