### PR TITLE
SelectCategory.php: Cast $value to string

### DIFF
--- a/src/FilterService/FilterType/ElasticSearch/SelectCategory.php
+++ b/src/FilterService/FilterType/ElasticSearch/SelectCategory.php
@@ -77,7 +77,7 @@ class SelectCategory extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
         $currentFilter[$filterDefinition->getField()] = $value;
 
         if (!empty($value)) {
-            $value = trim($value);
+            $value = trim((string)$value);
             $productList->addCondition($value, $filterDefinition->getField());
         }
 


### PR DESCRIPTION
$value can set with an int value (line 73) by "getId()". Trim throws in strict mode an error, if it doesn't get a string. Therefore we need to cast $value to a string.