### PR TITLE
[BUGFIX] SelectCategory.php: Cast $value to string

### DIFF
--- a/src/FilterService/FilterType/ElasticSearch/SelectCategory.php
+++ b/src/FilterService/FilterType/ElasticSearch/SelectCategory.php
@@ -70,7 +70,7 @@ class SelectCategory extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
         } elseif (empty($value) && !$isReload && method_exists($filterDefinition, 'getPreSelect')) {
             $value = $filterDefinition->getPreSelect();
             if ($value instanceof ElementInterface) {
-                $value = $value->getId();
+                $value = (string)$value->getId();
             }
         }
 


### PR DESCRIPTION
$value can set with an int value (line 73) by "getId()". Trim throws in strict mode an error, if it doesn't get a string. Therefore we need to cast $value to a string.

