### PR TITLE
[bugfix] Fix voucher token max usage limit

### DIFF
--- a/src/VoucherService/Token.php
+++ b/src/VoucherService/Token.php
@@ -88,7 +88,7 @@ class Token extends AbstractModel
     public function check(int $maxUsages = null, bool $isCheckout = false): bool
     {
         if (isset($maxUsages)) {
-            if ($this->getUsages() + Reservation::getReservationCount($this->getToken()) - (int)$isCheckout <= $maxUsages) {
+            if ($this->getUsages() + Reservation::getReservationCount($this->getToken()) - (int)$isCheckout < $maxUsages) {
                 return true;
             }
 


### PR DESCRIPTION
Before the change, this situation was possible:  
![image](https://github.com/pimcore/ecommerce-framework-bundle/assets/79514353/ce19a95c-18e6-4f2d-9466-7b69053af22e)


The expected behavior is that you can't apply a voucher token that has reached it's limit.
The actual behavior is that the voucher token's limit is `usages + 1`.

