### PR TITLE
Throw max usage reached exception

### DIFF
--- a/src/VoucherService/TokenManager/Single.php
+++ b/src/VoucherService/TokenManager/Single.php
@@ -19,6 +19,7 @@ namespace Pimcore\Bundle\EcommerceFrameworkBundle\VoucherService\TokenManager;
 use Knp\Component\Pager\PaginatorInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Exception\InvalidConfigException;
+use Pimcore\Bundle\EcommerceFrameworkBundle\Exception\VoucherServiceException;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractOrder;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Model\AbstractVoucherTokenType;
 use Pimcore\Bundle\EcommerceFrameworkBundle\VoucherService\Reservation;
@@ -259,6 +260,8 @@ class Single extends AbstractTokenManager implements ExportableTokenManagerInter
             if ($token->check((int)$this->configuration->getUsages())) {
                 return true;
             }
+
+            throw new VoucherServiceException('Max usage limit reached.', VoucherServiceException::ERROR_CODE_NO_MORE_USAGES);
         }
 
         return false;


### PR DESCRIPTION
Allow developers to catch the `VoucherServiceException` that takes place when voucher token's max usage limit has reached. This is necessary for displaying correct error message (`'cart.error-voucher-code-' . $e->getCode()`) to the end user.