### PR TITLE
Array flip makes voucher strings to int

### DIFF
--- a/src/OrderManager/V7/OrderManager.php
+++ b/src/OrderManager/V7/OrderManager.php
@@ -708,7 +708,7 @@ class OrderManager implements OrderManagerInterface
 
             //add new tokens - which are the remaining entries of $flippedVoucherTokens
             foreach ($flippedVoucherTokens as $code => $x) {
-                $this->voucherService->applyToken($code, $cart, $order);
+                $this->voucherService->applyToken((string)$code, $cart, $order);
             }
         }
     }

--- a/src/PricingManager/Rule.php
+++ b/src/PricingManager/Rule.php
@@ -120,7 +120,7 @@ class Rule extends AbstractModel implements RuleInterface
                         return $this;
                     }
             }
-            $this->$method($value ?? '');
+            $this->$method($value);
         }
 
         return $this;

--- a/src/PricingManager/Rule.php
+++ b/src/PricingManager/Rule.php
@@ -120,7 +120,7 @@ class Rule extends AbstractModel implements RuleInterface
                         return $this;
                     }
             }
-            $this->$method($value);
+            $this->$method($value ?? '');
         }
 
         return $this;

--- a/src/VoucherService/TokenManager/Single.php
+++ b/src/VoucherService/TokenManager/Single.php
@@ -207,7 +207,7 @@ class Single extends AbstractTokenManager implements ExportableTokenManagerInter
     public function applyToken(string $code, CartInterface $cart, AbstractOrder $order): OnlineShopVoucherToken|bool
     {
         if ($token = Token::getByCode($code)) {
-            if ($token->check($this->configuration->getUsages(), true)) {
+            if ($token->check((int)$this->configuration->getUsages(), true)) {
                 if ($token->apply()) {
                     $orderToken = \Pimcore\Model\DataObject\OnlineShopVoucherToken::getByToken($code, 1);
                     if (!$orderToken instanceof \Pimcore\Model\DataObject\OnlineShopVoucherToken) {


### PR DESCRIPTION
When adding voucher-tokens that are all numbers the array_flip function will make the values to int's so we need to cast to string in OrderManager.
We also need to cast to int when reading configuration->getUsages() because it returns string.