### PR TITLE
Add events to CommitOrderProcessor cleanUpPendingOrders method

### DIFF
--- a/src/CheckoutManager/V7/CommitOrderProcessor.php
+++ b/src/CheckoutManager/V7/CommitOrderProcessor.php
@@ -34,6 +34,7 @@ use Pimcore\Logger;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -329,7 +330,6 @@ class CommitOrderProcessor implements CommitOrderProcessorInterface, LoggerAware
 
         //Abort orders with payment pending
         $list = $orderManager->buildOrderList();
-        $list->addFieldCollection('PaymentInfo');
         $list->setCondition(
             'orderState = ? AND modificationDate < ?',
             [AbstractOrder::ORDER_STATE_PAYMENT_PENDING, $timestamp]
@@ -339,7 +339,14 @@ class CommitOrderProcessor implements CommitOrderProcessorInterface, LoggerAware
         foreach ($list as $order) {
             Logger::warn('Setting order ' . $order->getId() . ' to ' . AbstractOrder::ORDER_STATE_ABORTED);
             $order->setOrderState(AbstractOrder::ORDER_STATE_ABORTED);
-            $order->save(['versionNote' => 'CommitOrderProcessor::cleanUpPendingOrders - set state to aborted.']);
+            $parameters = ['versionNote' => 'CommitOrderProcessor::cleanUpPendingOrders - set state to aborted.'];
+
+            $pendingOrderEvent = new CommitOrderProcessorEvent($this, $order, ['parameters' => $parameters]);
+            $this->eventDispatcher->dispatch($pendingOrderEvent, CommitOrderProcessorEvents::PRE_CLEANUP_PENDING_ORDER);
+            $order = $pendingOrderEvent->getOrder();
+            $parameters = array_merge($parameters, $pendingOrderEvent->getArgument('parameters'));
+
+            $order->save($parameters);
         }
 
         //Abort payments with payment pending
@@ -353,6 +360,7 @@ class CommitOrderProcessor implements CommitOrderProcessorInterface, LoggerAware
         /** @var AbstractOrder $order */
         foreach ($list as $order) {
             $paymentInformationCollection = $order->getPaymentInfo();
+            $parameters = ['versionNote' => 'CommitOrderProcessor::cleanUpPendingOrders - set state to aborted.'];
 
             /** @var AbstractPaymentInformation $paymentInfo */
             foreach ($paymentInformationCollection as $paymentInfo) {
@@ -369,9 +377,14 @@ class CommitOrderProcessor implements CommitOrderProcessorInterface, LoggerAware
                         )
                     );
                     $paymentInfo->setPaymentState(AbstractOrder::ORDER_STATE_ABORTED);
+
+                    $pendingPaymentEvent = new GenericEvent($paymentInfo, ['parameters' => $parameters]);
+                    $this->eventDispatcher->dispatch($pendingPaymentEvent, CommitOrderProcessorEvents::PRE_CLEANUP_PENDING_PAYMENT);
+                    $paymentInfo = $pendingPaymentEvent->getSubject();
+                    $parameters = array_merge($parameters, $pendingPaymentEvent->getArgument('parameters'));
                 }
             }
-            $order->save(['versionNote' => 'CommitOrderProcessor:cleanupPendingOrders- payment aborted.']);
+            $order->save($parameters);
         }
     }
 }

--- a/src/Event/CommitOrderProcessorEvents.php
+++ b/src/Event/CommitOrderProcessorEvents.php
@@ -47,6 +47,20 @@ final class CommitOrderProcessorEvents
     const POST_COMMIT_ORDER = 'pimcore.ecommerce.commitorderprocessor.postCommitOrder';
 
     /**
+     * @Event("Pimcore\Bundle\EcommerceFrameworkBundle\Event\Model\CommitOrderProcessorEvent")
+     *
+     * @var string
+     */
+    const PRE_CLEANUP_PENDING_ORDER = 'pimcore.ecommerce.commitorderprocessor.preCleanupPendingOrder';
+
+    /**
+     * @Event("Pimcore\Bundle\EcommerceFrameworkBundle\Event\Model\CommitOrderProcessorEvent")
+     *
+     * @var string
+     */
+    const PRE_CLEANUP_PENDING_PAYMENT = 'pimcore.ecommerce.commitorderprocessor.preCleanupPendingPayment';
+
+    /**
      * @Event("Pimcore\Bundle\EcommerceFrameworkBundle\Event\Model\SendConfirmationMailEvent")
      *
      * @var string


### PR DESCRIPTION
It would be super cool if the cleanUpPendingOrders method would throw events before setting a pending order to "aborted".
In my specific UseCase i want to do some other stuff aswell, if the order gets cleaned up by e.g. the maintenance cron job.

I tested these Events and they worked well for me.
I hope this gets pulled :)
