### PR TITLE
Cast value to string for selectCategory

### DIFF
--- a/src/FilterService/FilterType/ElasticSearch/SelectCategory.php
+++ b/src/FilterService/FilterType/ElasticSearch/SelectCategory.php
@@ -77,7 +77,7 @@ class SelectCategory extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
         $currentFilter[$filterDefinition->getField()] = $value;
 
         if (!empty($value)) {
-            $value = trim($value);
+            $value = trim((string)$value);
             $productList->addCondition($value, $filterDefinition->getField());
         }
 


### PR DESCRIPTION
trim might cause an error in case of an actual id (int) being given instead of a string. cast to string to avoid this (see https://github.com/pimcore/ecommerce-framework-bundle/blob/1.x/src/FilterService/FilterType/ElasticSearch/SelectCategory.php#L73)