### PR TITLE
fix trim on null

### DIFF
--- a/src/FilterService/FilterType/ElasticSearch/SelectFromMultiSelect.php
+++ b/src/FilterService/FilterType/ElasticSearch/SelectFromMultiSelect.php
@@ -41,7 +41,7 @@ class SelectFromMultiSelect extends \Pimcore\Bundle\EcommerceFrameworkBundle\Fil
             $value = $preSelect;
         }
 
-        if (!empty($value) {
+        if (!empty($value)) {
             $value = trim($value);
         }
 

--- a/src/FilterService/FilterType/ElasticSearch/SelectFromMultiSelect.php
+++ b/src/FilterService/FilterType/ElasticSearch/SelectFromMultiSelect.php
@@ -41,7 +41,9 @@ class SelectFromMultiSelect extends \Pimcore\Bundle\EcommerceFrameworkBundle\Fil
             $value = $preSelect;
         }
 
-        $value = trim($value);
+        if (!empty($value) {
+            $value = trim($value);
+        }
 
         $currentFilter[$field] = $value;
 


### PR DESCRIPTION
the value might be null in case of it being an empty string and other occasions
(see: https://github.com/AlternateIf/ecommerce-framework-bundle/blob/4a2b7cdb5dc4f4f432f111400a4b8507e4a893f2/src/FilterService/FilterType/ElasticSearch/SelectFromMultiSelect.php#L39)

a null value can't be trimmed and causes an error. 
adresses #166 