### PR TITLE
Lazy load products in `CatalogProduct` condition

### DIFF
--- a/src/PricingManager/Condition/CatalogProduct.php
+++ b/src/PricingManager/Condition/CatalogProduct.php
@@ -166,6 +166,7 @@ class CatalogProduct extends AbstractObjectListCondition implements CatalogProdu
             );
 
             $result = null;
+
             return $result;
         }
 

--- a/src/PricingManager/Condition/CatalogProduct.php
+++ b/src/PricingManager/Condition/CatalogProduct.php
@@ -116,7 +116,11 @@ class CatalogProduct extends AbstractObjectListCondition implements CatalogProdu
      */
     public function __sleep(): array
     {
-        return $this->handleSleep('products', 'productIds');
+        if (isset($this->products)) {
+            return $this->handleSleep('products', 'productIds');
+        }
+
+        return ['productIds'];
     }
 
     /**

--- a/src/PricingManager/Condition/CatalogProduct.php
+++ b/src/PricingManager/Condition/CatalogProduct.php
@@ -150,7 +150,7 @@ class CatalogProduct extends AbstractObjectListCondition implements CatalogProdu
      *
      * @todo: move the lazy initialization into {@see getProducts()} for Pimcore 12
      */
-    public function &__get(string $name)
+    public function &__get(string $name): mixed
     {
         $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
 

--- a/src/PricingManager/Condition/CatalogProduct.php
+++ b/src/PricingManager/Condition/CatalogProduct.php
@@ -27,14 +27,14 @@ class CatalogProduct extends AbstractObjectListCondition implements CatalogProdu
     /**
      * @var AbstractProduct[]
      *
-     * @deprecated Will be internal in Pimcore 12
+     * @deprecated Will be internal in version 2 of the ecommerce framework
      */
     protected array $products = [];
 
     /**
      * Serialized product IDs
      *
-     * @deprecated Will be internal in Pimcore 12
+     * @deprecated Will be internal in version 2 of the ecommerce framework
      */
     protected array $productIds = [];
 
@@ -148,7 +148,7 @@ class CatalogProduct extends AbstractObjectListCondition implements CatalogProdu
     /**
      * This lazily initializes the "products" property in a backwards compatible way.
      *
-     * @todo: move the lazy initialization into {@see getProducts()} for Pimcore 12
+     * @todo: move the lazy initialization into {@see getProducts()} for version 2 of the ecommerce framework
      */
     public function &__get(string $name): mixed
     {

--- a/src/PricingManager/Condition/CatalogProduct.php
+++ b/src/PricingManager/Condition/CatalogProduct.php
@@ -57,16 +57,13 @@ class CatalogProduct extends AbstractObjectListCondition implements CatalogProdu
 
         // test
         foreach ($productsPool as $currentProduct) {
-            // check all valid products
-            foreach ($this->productIds as $productId) {
-                /** @var Concrete $currentProductCheck */
-                $currentProductCheck = $currentProduct;
-                while ($currentProductCheck instanceof CheckoutableInterface) {
-                    if ($currentProductCheck->getId() === $productId) {
-                        return true;
-                    }
-                    $currentProductCheck = $currentProductCheck->getParent();
+            /** @var Concrete $currentProductCheck */
+            $currentProductCheck = $currentProduct;
+            while ($currentProductCheck instanceof CheckoutableInterface) {
+                if (in_array($currentProductCheck->getId(), $this->productIds)) {
+                    return true;
                 }
+                $currentProductCheck = $currentProductCheck->getParent();
             }
         }
 


### PR DESCRIPTION
We have a case where our client has created multiple pricing rules, each with tens of products in the `CatalogProduct` condition. 

This turns out to be very expensive, because Pimcore loads every product of every rule (which means `n+1 = hundreds` of DB queries or cache requests) just to compare their IDs and figure out if the condition matches and the rule should be applied.

But we already *have* the IDs because they get serialized with the condition anyway! So we could lazy-load the products only when really necessary and just use the IDs in the `check()` method.

---

A problem is, that the `$products` and `$productIds` properties are `protected` because the `parent` class needs to access them to prepare them for (de)serialization. 

Sadly, they're not marked as `@internal` either, so it would be a breaking change to just alter their behavior. 

This is why we need to implement a magic getter (this would be a good case for [`property hooks`](https://wiki.php.net/rfc/property-hooks) which will come in PHP 8.4 by the way!) for them until they can be marked as `@internal` (or `AbstractObjectListCondition` gets converted into a `trait` and the properties could be `private`) in the next major, and we can move the lazy initialization into `getProducts()`.