### PR TITLE
fix type for substr in elasticsearch

### DIFF
--- a/src/IndexService/Config/ElasticSearch.php
+++ b/src/IndexService/Config/ElasticSearch.php
@@ -202,7 +202,7 @@ class ElasticSearch extends AbstractConfig implements MockupConfigInterface, Ela
         $fieldNamePart = $fullFieldName;
         while (!empty($fieldNamePart)) {
             // cut off part after last .
-            $fieldNamePart = substr($fieldNamePart, 0,(int) strripos($fieldNamePart, '.'));
+            $fieldNamePart = substr($fieldNamePart, 0, (int) strripos($fieldNamePart, '.'));
 
             // search for mapping with field name part
             $fieldName = array_search($fieldNamePart, $this->fieldMapping);

--- a/src/IndexService/Config/ElasticSearch.php
+++ b/src/IndexService/Config/ElasticSearch.php
@@ -202,7 +202,7 @@ class ElasticSearch extends AbstractConfig implements MockupConfigInterface, Ela
         $fieldNamePart = $fullFieldName;
         while (!empty($fieldNamePart)) {
             // cut off part after last .
-            $fieldNamePart = substr($fieldNamePart, 0, strripos($fieldNamePart, '.'));
+            $fieldNamePart = substr($fieldNamePart, 0,(int) strripos($fieldNamePart, '.'));
 
             // search for mapping with field name part
             $fieldName = array_search($fieldNamePart, $this->fieldMapping);


### PR DESCRIPTION
the method substr requires ?int as a third parameter. in case of a fieldname ($fullFieldName) being for example  "floorSurface" (without any analyzers etc.) strripos will return false upon not finding a '.' and thus making substr fail since it got a bool as third parameter 