### PR TITLE
Bugfix: Prevent error/warning

### DIFF
--- a/src/FilterService/FilterType/ElasticSearch/Input.php
+++ b/src/FilterService/FilterType/ElasticSearch/Input.php
@@ -42,7 +42,10 @@ class Input extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\Filte
             $value = $preSelect;
         }
 
-        $value = trim($value);
+        if(is_string($value)){
+            $value = trim($value);
+        }
+
         $currentFilter[$field] = $value;
 
         if (!empty($value)) {

--- a/src/FilterService/FilterType/ElasticSearch/Input.php
+++ b/src/FilterService/FilterType/ElasticSearch/Input.php
@@ -42,7 +42,7 @@ class Input extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\Filte
             $value = $preSelect;
         }
 
-        if(is_string($value)){
+        if(is_string($value)) {
             $value = trim($value);
         }
 


### PR DESCRIPTION
Prevent error/warning
"trim(): Argument https://github.com/pimcore/ecommerce-framework-bundle/issues/1 ($string) must be of type string, null given"

because trim() is only applyable on strings - not if it is null