### PR TITLE
IndexFieldSelection preSelect can also be integer

### DIFF
--- a/src/CoreExtensions/ObjectData/IndexFieldSelection.php
+++ b/src/CoreExtensions/ObjectData/IndexFieldSelection.php
@@ -23,14 +23,14 @@ class IndexFieldSelection
     public string $field;
 
     /**
-     * @var string|string[]|null
+     * @var string|string[]|int|null
      */
-    public string|array|null $preSelect;
+    public string|array|int|null $preSelect;
 
     /**
-     * @param string|string[] $preSelect
+     * @param string|string[]|int $preSelect
      */
-    public function __construct(?string $tenant, string $field, array|string|null $preSelect)
+    public function __construct(?string $tenant, string $field, array|string|int|null $preSelect)
     {
         $this->field = $field;
         $this->preSelect = $preSelect;
@@ -50,7 +50,7 @@ class IndexFieldSelection
     /**
      * @param string|string[] $preSelect
      */
-    public function setPreSelect(array|string $preSelect): void
+    public function setPreSelect(array|string|int $preSelect): void
     {
         $this->preSelect = $preSelect;
     }
@@ -58,7 +58,7 @@ class IndexFieldSelection
     /**
      * @return string|string[]|null
      */
-    public function getPreSelect(): array|string|null
+    public function getPreSelect(): array|string|int|null
     {
         return $this->preSelect;
     }

--- a/src/FilterService/FilterType/AbstractFilterType.php
+++ b/src/FilterService/FilterType/AbstractFilterType.php
@@ -81,7 +81,7 @@ abstract class AbstractFilterType
         return $template;
     }
 
-    protected function getPreSelect(AbstractFilterDefinitionType $filterDefinition): array|string|null
+    protected function getPreSelect(AbstractFilterDefinitionType $filterDefinition): array|string|int|null
     {
         $field = $filterDefinition->getField();
         if ($field instanceof IndexFieldSelection) {


### PR DESCRIPTION
When you use Index Service to index a relation, the ids are stored in database in INT column.
When you try to use this indexed value in the filter as a preselected value, it cannot be saved because of the typehint.

`Pimcore\Bundle\EcommerceFrameworkBundle\CoreExtensions\ObjectData\IndexFieldSelection::__construct(): Argument #3 ($preSelect) must be of type array|string|null, int given, called in vendor\pimcore\ecommerce-framework-bundle\src\CoreExtensions\ClassDefinition\IndexFieldSelection.php on line 162`

Steps to reproduce:
1. create a DataObject for FilterDefinition
2. add a "Filter Relation" to Filters
3. chose a value for "Pre Select" field
4. save the DataObject

Alternatively, another possible way to fix this is to convert the preSelect value to string here (let me know if you prefer this solution so I can adjust the PR):  https://github.com/pimcore/ecommerce-framework-bundle/blob/56418f9a7685f98add841198a1b6d471e5cf50fb/src/CoreExtensions/ClassDefinition/IndexFieldSelection.php#L162