### PR TITLE
Drop twig deferred blocks and deprecated pimcore_* twig extension calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+#### v1.2.1
+- Removed the package "rybakit/twig-deferred-extension". If you extend the twig layout from the E-Commerce Framework, please check if custom CSS/JS code added by `pimcore_head_script` and `pimcore_head_link` is still working. 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     "pimcore/google-marketing-bundle": "^1.0",
     "knplabs/knp-paginator-bundle": "^6.0.0",
     "symfony/webpack-encore-bundle": "^1.13.2",
-    "rybakit/twig-deferred-extension": "^3.0",
     "symfony/form": "^6.2"
   },
   "require-dev": {
@@ -32,9 +31,6 @@
     "codeception/module-symfony":"^3.1.1",
     "elasticsearch/elasticsearch": "^8.0",
     "pimcore/elasticsearch-client": "^1.0.0"
-  },
-  "conflict": {
-    "twig/twig": "^3.9.0"
   },
   "suggest": {
     "elasticsearch/elasticsearch": "Required for Elastic Search service",

--- a/src/IndexService/Getter/DefaultBrickGetterSequenceToMultiselect.php
+++ b/src/IndexService/Getter/DefaultBrickGetterSequenceToMultiselect.php
@@ -56,7 +56,7 @@ class DefaultBrickGetterSequenceToMultiselect implements GetterInterface
                         if (is_bool($value) || $source['forceBool']) {
                             $values[] = $source['fieldname'];
                         } else {
-                            if(is_array($value)) {
+                            if (is_array($value)) {
                                 $values = array_merge($values, $value);
                             } else {
                                 $values[] = $value;
@@ -77,7 +77,7 @@ class DefaultBrickGetterSequenceToMultiselect implements GetterInterface
                         if (is_bool($value) || $source['forceBool']) {
                             $values[] = $source['fieldname'];
                         } else {
-                            if(is_array($value)) {
+                            if (is_array($value)) {
                                 $values = array_merge($values, $value);
                             } else {
                                 $values[] = $value;

--- a/src/IndexService/IndexUpdateService.php
+++ b/src/IndexService/IndexUpdateService.php
@@ -186,7 +186,7 @@ class IndexUpdateService
             return;
         }
 
-        if(is_array($tenantNameList)  && count($tenantNameList) === 0) {
+        if (is_array($tenantNameList)  && count($tenantNameList) === 0) {
             return;
         }
 

--- a/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -1075,7 +1075,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
                 $data['key_as_string'] = $bucket['key_as_string'];
             } elseif (is_array($reverseAggregationBucket) && array_key_exists('doc_count', $reverseAggregationBucket)) { // reverse aggregation
                 $data['reverse_count'] = $reverseAggregationBucket['doc_count'];
-            } elseif(is_array($subAggregationBuckets) && isset($subAggregationBuckets['buckets'])) {        // sub aggregations
+            } elseif (is_array($subAggregationBuckets) && isset($subAggregationBuckets['buckets'])) {        // sub aggregations
                 foreach ($subAggregationBuckets['buckets'] as $bucket) {
                     $data[$subAggregationField][] = $this->convertBucketValues($bucket);
                 }

--- a/src/Model/Currency.php
+++ b/src/Model/Currency.php
@@ -73,7 +73,7 @@ class Currency
 
     public function toCurrency(null|float|int|string|Decimal $value, array|string $pattern = 'default'): string
     {
-        if($value == null) {
+        if ($value == null) {
             return '';
         }
 

--- a/src/Model/DefaultMockup.php
+++ b/src/Model/DefaultMockup.php
@@ -122,7 +122,7 @@ class DefaultMockup implements ProductInterface, LinkGeneratorAwareInterface, In
             $attributeName = substr($method, 3);
         }
 
-        foreach([$attributeName, lcfirst($attributeName)] as $attrName) {
+        foreach ([$attributeName, lcfirst($attributeName)] as $attrName) {
 
             if (is_array($this->params) && array_key_exists($attrName, $this->params)) {
                 return $this->params[$attrName];

--- a/src/PricingManager/Condition/DateRange.php
+++ b/src/PricingManager/Condition/DateRange.php
@@ -73,13 +73,13 @@ class DateRange implements DateRangeInterface
         $json = json_decode($string);
 
         $starting = \DateTime::createFromFormat('d.m.Y', $json->starting, new DateTimeZone('UTC'));
-        if($starting instanceof \DateTime) {
+        if ($starting instanceof \DateTime) {
             $starting->setTime(0, 0, 0);
             $this->setStarting($starting);
         }
 
         $ending = \DateTime::createFromFormat('d.m.Y', $json->ending, new DateTimeZone('UTC'));
-        if($ending instanceof \DateTime) {
+        if ($ending instanceof \DateTime) {
             $ending->setTime(23, 59, 59);
             $this->setEnding($ending);
         }

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -22,8 +22,3 @@ services:
         resource: '../../Controller'
         public: true
         tags: ['controller.service_arguments']
-
-    # the deferred extension is needed for placeholder helpers to work
-    # as otherwise the placeholder block would be rendered before any
-    # content was added (e.g. headTitle)
-    Twig\DeferredExtension\DeferredExtension: ~

--- a/src/Resources/views/admin_order/detail.html.twig
+++ b/src/Resources/views/admin_order/detail.html.twig
@@ -411,7 +411,7 @@
         </div>
     </div>
 
-    {% do pimcore_head_script().captureStart() %}
+    {% set inlineScript %}
         document.addEventListener("DOMContentLoaded", function(event) {
             // pimcore open object
             document.querySelectorAll('[data-action=open]').forEach(function(el){
@@ -448,5 +448,6 @@
             {% endif %}
 
         });
-    {% do pimcore_head_script().captureEnd() %}
+    {% endset %}
+    {% do pimcore_head_script().appendScript(inlineScript ~ "") %}
 {% endblock %}

--- a/src/Resources/views/admin_order/list.html.twig
+++ b/src/Resources/views/admin_order/list.html.twig
@@ -105,7 +105,7 @@
         {% include "@PimcoreEcommerceFramework/includes/paging.html.twig" with {'paginationVariables': paginator.getPaginationData() } %}
     {% endif %}
 
-    {% do pimcore_head_script().captureStart() %}
+    {% set inlineScript %}
             //datepicker
             flatpickr(".date", {allowInput: true});
 
@@ -116,7 +116,9 @@
                 });
             });
 
-    {% do pimcore_head_script().captureEnd() %}
+    {% endset %}
+
+    {% do pimcore_head_script().appendScript(inlineScript ~ "") %}
 {% endblock %}
 
 

--- a/src/Resources/views/back-office.html.twig
+++ b/src/Resources/views/back-office.html.twig
@@ -24,7 +24,7 @@
             {% do pimcore_head_script().prependFile(asset('/bundles/pimcoreecommerceframework/vendor/bootstrap4/js/bootstrap-native-v4.min.js')) %}
         {% endapply %}
 
-        {% block head_stylesheets deferred %}
+        {% block head_stylesheets %}
             {{ pimcore_head_link() }}
         {% endblock %}
 
@@ -79,7 +79,7 @@
     </div>
 
     {# output scripts added before #}
-    {% block scripts deferred %}
+    {% block scripts %}
         {{ pimcore_head_script() }}
     {% endblock %}
 

--- a/src/Resources/views/voucher/voucher_layout.html.twig
+++ b/src/Resources/views/voucher/voucher_layout.html.twig
@@ -19,13 +19,13 @@
         {% do pimcore_head_script().appendFile(asset('/bundles/pimcoreecommerceframework/js/voucherservice/voucherSeriesTabScript.js')) %}
     {% endapply %}
 
-    {% block head_stylesheets deferred %}
+    {% block head_stylesheets %}
         {{ pimcore_head_link() }}
     {% endblock %}
 </head>
 <body>
     {# output scripts added before #}
-    {% block scripts deferred %}
+    {% block scripts %}
         {{ pimcore_head_script() }}
     {% endblock %}
     {% set colors = {


### PR DESCRIPTION
Related to 
https://github.com/pimcore/pimcore/pull/17444
https://github.com/pimcore/customer-data-framework/pull/540

* Deferred blocks are not needed, everthing works without the `deferred` attribute too. As this extension does not work with twig >=3.9.0 it's removed now.
  * The only exception could be if someone extends the ecommerce framework twig layouts in custom code and calls the `pimcore_head_link` extension within the content/body block. In that case the call would need to be moved outside of the block. 

* The deprecated usage of `pimcore_head_script().captureStart()` is replaced with an alternative approach.
