### PR TITLE
fix(filterDefinition): select preSelect values in backend ui

### DIFF
--- a/src/Resources/public/js/indexfieldselectionfield/tags/indexFieldSelection.js
+++ b/src/Resources/public/js/indexfieldselectionfield/tags/indexFieldSelection.js
@@ -62,10 +62,10 @@ pimcore.object.tags.indexFieldSelection = Class.create(pimcore.object.tags.selec
                     load: function(store) {
                         if(this.data) {
                             if(this.preSelectCombobox.rendered) {
-                                this.preSelectCombobox.setValue(this.data.preSelect);
+                                this.preSelectCombobox.setValue(this.data.preSelect.split(',').map(Number));
                             } else {
                                 this.preSelectCombobox.addListener("afterRender", function() {
-                                    this.preSelectCombobox.setValue(this.data.preSelect);
+                                    this.preSelectCombobox.setValue(this.data.preSelect.split(',').map(Number));
                                 }.bind(this));
                             }
                         }
@@ -239,10 +239,10 @@ pimcore.object.tags.indexFieldSelection = Class.create(pimcore.object.tags.selec
 
         if(this.fieldConfig.multiPreSelect == 'local_single' || this.fieldConfig.multiPreSelect == 'local_multi') {
             if(this.preSelectCombobox.rendered) {
-                this.preSelectCombobox.setValue(this.data.preSelect);
+                this.preSelectCombobox.setValue(this.data.preSelect.split(',').map(Number));
             } else {
                 this.preSelectCombobox.addListener("afterRender", function() {
-                    this.preSelectCombobox.setValue(this.data.preSelect);
+                    this.preSelectCombobox.setValue(this.data.preSelect.split(',').map(Number));
                 }.bind(this));
             }
         }


### PR DESCRIPTION
Selected values are not active after reloading FilterDefinition Objekt.

Steps to reproduce (can be reproduced in pimcore demo):
* Open FilterDefinition object
* Add or change selected values of "FilterMultiRelation" fieldcollection in Precondition or filters tab
* Reload object and navigate to changed fieldcollection
* Nothing is preselected

Problem is a string integer compare in ExtJS, fix is to convert the preselected values into a integer array.