### PR TITLE
fix: category id needs to be casted to string for trim function

### DIFF
--- a/src/FilterService/FilterType/MultiSelectCategory.php
+++ b/src/FilterService/FilterType/MultiSelectCategory.php
@@ -96,7 +96,7 @@ class MultiSelectCategory extends AbstractFilterType
                     $category = $category->getId();
                 }
 
-                $category = '%,' . trim($category) . ',%';
+                $category = '%,' . trim((string)$category) . ',%';
 
                 $conditions[] = $filterDefinition->getField() . ' LIKE ' . $db->quote($category);
             }


### PR DESCRIPTION
this throws an error if $category is an object as getId() returns int