### PR TITLE
fix: .map(Number) creates problems if preselect is not an id but a string

### DIFF
--- a/src/Resources/public/js/indexfieldselectionfield/tags/indexFieldSelection.js
+++ b/src/Resources/public/js/indexfieldselectionfield/tags/indexFieldSelection.js
@@ -62,10 +62,10 @@ pimcore.object.tags.indexFieldSelection = Class.create(pimcore.object.tags.selec
                     load: function(store) {
                         if(this.data) {
                             if(this.preSelectCombobox.rendered) {
-                                this.preSelectCombobox.setValue(this.data.preSelect?.split(',').map(Number));
+                                this.preSelectCombobox.setValue(this.fieldConfig.filterGroups?.includes('relation') ? this.data.preSelect?.split(',').map(Number) : this.data.preSelect?.split(','));
                             } else {
                                 this.preSelectCombobox.addListener("afterRender", function() {
-                                    this.preSelectCombobox.setValue(this.data.preSelect?.split(',').map(Number));
+                                    this.preSelectCombobox.setValue(this.fieldConfig.filterGroups?.includes('relation') ? this.data.preSelect?.split(',').map(Number) : this.data.preSelect?.split(','));
                                 }.bind(this));
                             }
                         }
@@ -239,10 +239,10 @@ pimcore.object.tags.indexFieldSelection = Class.create(pimcore.object.tags.selec
 
         if(this.fieldConfig.multiPreSelect == 'local_single' || this.fieldConfig.multiPreSelect == 'local_multi') {
             if(this.preSelectCombobox.rendered) {
-                this.preSelectCombobox.setValue(this.data.preSelect?.split(',').map(Number));
+                this.preSelectCombobox.setValue(this.fieldConfig.filterGroups?.includes('relation') ? this.data.preSelect?.split(',').map(Number) : this.data.preSelect?.split(','));
             } else {
                 this.preSelectCombobox.addListener("afterRender", function() {
-                    this.preSelectCombobox.setValue(this.data.preSelect?.split(',').map(Number));
+                    this.preSelectCombobox.setValue(this.fieldConfig.filterGroups?.includes('relation') ? this.data.preSelect?.split(',').map(Number) : this.data.preSelect?.split(','));
                 }.bind(this));
             }
         }

--- a/src/Resources/public/js/indexfieldselectionfield/tags/indexFieldSelection.js
+++ b/src/Resources/public/js/indexfieldselectionfield/tags/indexFieldSelection.js
@@ -62,10 +62,10 @@ pimcore.object.tags.indexFieldSelection = Class.create(pimcore.object.tags.selec
                     load: function(store) {
                         if(this.data) {
                             if(this.preSelectCombobox.rendered) {
-                                this.preSelectCombobox.setValue(this.fieldConfig.filterGroups?.includes('relation') ? this.data.preSelect?.split(',').map(Number) : this.data.preSelect?.split(','));
+                                this.preSelectCombobox.setValue(this.getPreselectValue());
                             } else {
                                 this.preSelectCombobox.addListener("afterRender", function() {
-                                    this.preSelectCombobox.setValue(this.fieldConfig.filterGroups?.includes('relation') ? this.data.preSelect?.split(',').map(Number) : this.data.preSelect?.split(','));
+                                    this.preSelectCombobox.setValue(this.getPreselectValue());
                                 }.bind(this));
                             }
                         }
@@ -239,10 +239,10 @@ pimcore.object.tags.indexFieldSelection = Class.create(pimcore.object.tags.selec
 
         if(this.fieldConfig.multiPreSelect == 'local_single' || this.fieldConfig.multiPreSelect == 'local_multi') {
             if(this.preSelectCombobox.rendered) {
-                this.preSelectCombobox.setValue(this.fieldConfig.filterGroups?.includes('relation') ? this.data.preSelect?.split(',').map(Number) : this.data.preSelect?.split(','));
+                this.preSelectCombobox.setValue(this.getPreselectValue());
             } else {
                 this.preSelectCombobox.addListener("afterRender", function() {
-                    this.preSelectCombobox.setValue(this.fieldConfig.filterGroups?.includes('relation') ? this.data.preSelect?.split(',').map(Number) : this.data.preSelect?.split(','));
+                    this.preSelectCombobox.setValue(this.getPreselectValue());
                 }.bind(this));
             }
         }
@@ -262,5 +262,12 @@ pimcore.object.tags.indexFieldSelection = Class.create(pimcore.object.tags.selec
 
     isDirty: function() {
         return this.fieldsCombobox.isDirty() || (this.preSelectCombobox && this.preSelectCombobox.isDirty());
+    },
+
+    getPreselectValue: function() {
+        if(this.fieldConfig.filterGroups?.includes('relation')) {
+            return this.data.preSelect?.split(',').map(Number);
+        }
+        return this.data.preSelect?.split(',');
     }
 });


### PR DESCRIPTION
this checks if filterGroups in fieldConfig contains 'relation' and only maps to Number. This could still cause an issue if a field contains IDs and strings.  
I couldn't find a use case for this, but something to think about. Another solution would be to cast the key in FilterGroupHelper->getGroupValuesForFilterGroup to string and we can remove the map function altogether. The function is only used in the pimcore_ecommerceframework_index_getvaluesforfilterfield route and therefore should not cause other problems