### PR TITLE
[Task] Update webpack

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "pimcore/personalization-bundle": "^1.0",
     "pimcore/google-marketing-bundle": "^1.0",
     "knplabs/knp-paginator-bundle": "^6.0.0",
-    "symfony/webpack-encore-bundle": "^1.7 || ^2.0",
+    "symfony/webpack-encore-bundle": "^1.17 || ^2.0",
     "symfony/form": "^6.2"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "prefer-stable": true,
   "require": {
     "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-    "pimcore/pimcore": "dev-followup-upgrade as 11.x-dev",
+    "pimcore/pimcore": "^11.0.7",
     "pimcore/personalization-bundle": "^1.0",
     "pimcore/google-marketing-bundle": "^1.0",
     "knplabs/knp-paginator-bundle": "^6.0.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "pimcore/personalization-bundle": "^1.0",
     "pimcore/google-marketing-bundle": "^1.0",
     "knplabs/knp-paginator-bundle": "^6.0.0",
-    "symfony/webpack-encore-bundle": "^1.17 || ^2.0",
+    "symfony/webpack-encore-bundle": "^1.7 || ^2.0",
     "symfony/form": "^6.2"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "pimcore/personalization-bundle": "^1.0",
     "pimcore/google-marketing-bundle": "^1.0",
     "knplabs/knp-paginator-bundle": "^6.0.0",
-    "symfony/webpack-encore-bundle": "^1.17",
+    "symfony/webpack-encore-bundle": "^1.17 || ^2.0",
     "symfony/form": "^6.2"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "prefer-stable": true,
   "require": {
     "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-    "pimcore/pimcore": "^11.0.7",
+    "pimcore/pimcore": "dev-followup-upgrade as 11.x-dev",
     "pimcore/personalization-bundle": "^1.0",
     "pimcore/google-marketing-bundle": "^1.0",
     "knplabs/knp-paginator-bundle": "^6.0.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "pimcore/personalization-bundle": "^1.0",
     "pimcore/google-marketing-bundle": "^1.0",
     "knplabs/knp-paginator-bundle": "^6.0.0",
-    "symfony/webpack-encore-bundle": "^1.13.2",
+    "symfony/webpack-encore-bundle": "^1.17",
     "symfony/form": "^6.2"
   },
   "require-dev": {


### PR DESCRIPTION
Resolves #201 
Update to 1.17 possible
Restricted due to pimcore/admin-ui-classic-bundle

```
 - Root composer.json requires pimcore/admin-ui-classic-bundle * -> satisfiable by pimcore/admin-ui-classic-bundle[dev-722-fix-manual-sorting, 1.6.x-dev].
 - pimcore/admin-ui-classic-bundle 1.6.x-dev requires symfony/webpack-encore-bundle ^1.13.2 -> satisfiable by symfony/webpack-encore-bundle[v1.13.2, ..., v1.17.2].

```