### PR TITLE
Update MultiSelectFromMultiSelect filter for ElasticSearch

### DIFF
--- a/src/FilterService/FilterType/ElasticSearch/MultiSelectFromMultiSelect.php
+++ b/src/FilterService/FilterType/ElasticSearch/MultiSelectFromMultiSelect.php
@@ -53,13 +53,15 @@ class MultiSelectFromMultiSelect extends \Pimcore\Bundle\EcommerceFrameworkBundl
         if (empty($value) && !$isReload) {
             if (is_array($preSelect)) {
                 $value = $preSelect;
-            } else {
+            } elseif (is_string($preSelect)) {
                 $value = explode(',', $preSelect);
             }
 
-            foreach ($value as $key => $v) {
-                if (!$v) {
-                    unset($value[$key]);
+            if (is_iterable($value)) {
+                foreach ($value as $key => $v) {
+                    if (!$v) {
+                        unset($value[$key]);
+                    }
                 }
             }
         } elseif (!empty($value) && in_array(AbstractFilterType::EMPTY_STRING, $value)) {


### PR DESCRIPTION
$this->getPreSelect($filterDefinition) may return null and thus making $value = explode(',', $preSelect); fail

this PR fixes this behaviour