### PR TITLE
Bugfix(PricingRules): Prevent Error when adding a new Pricing Rule with a name that exists

### DIFF
--- a/src/PricingManager/Rule/Dao.php
+++ b/src/PricingManager/Rule/Dao.php
@@ -76,18 +76,13 @@ class Dao extends AbstractDao
      */
     public function save(): void
     {
-        try {
+        $this->db->transactional(function () {
             if (!$this->model->getId()) {
                 $this->create();
             }
 
             $this->update();
-            $this->db->commit();
-        } catch (\Exception $e) {
-            $this->db->rollBack();
-
-            throw $e;
-        }
+        });
 
     }
 

--- a/src/PricingManager/Rule/Dao.php
+++ b/src/PricingManager/Rule/Dao.php
@@ -76,11 +76,19 @@ class Dao extends AbstractDao
      */
     public function save(): void
     {
-        if (!$this->model->getId()) {
-            $this->create();
+        try {
+            if (!$this->model->getId()) {
+                $this->create();
+            }
+
+            $this->update();
+            $this->db->commit();
+        } catch (\Exception $e) {
+            $this->db->rollBack();
+
+            throw $e;
         }
 
-        $this->update();
     }
 
     public function update(): void

--- a/src/PricingManager/Rule/Dao.php
+++ b/src/PricingManager/Rule/Dao.php
@@ -66,8 +66,19 @@ class Dao extends AbstractDao
      */
     public function create(): void
     {
-        $this->db->insert(self::TABLE_NAME, []);
-        $this->model->setId((int) $this->db->lastInsertId());
+        try {
+            $this->db->beginTransaction();
+            if (!$this->model->getId()) {
+                $this->create();
+            }
+
+            $this->update();
+            $this->db->commit();
+        } catch (\Exception $e) {
+            $this->db->rollBack();
+
+            throw $e;
+        }
     }
 
     /**

--- a/src/PricingManager/Rule/Dao.php
+++ b/src/PricingManager/Rule/Dao.php
@@ -66,19 +66,8 @@ class Dao extends AbstractDao
      */
     public function create(): void
     {
-        try {
-            $this->db->beginTransaction();
-            if (!$this->model->getId()) {
-                $this->create();
-            }
-
-            $this->update();
-            $this->db->commit();
-        } catch (\Exception $e) {
-            $this->db->rollBack();
-
-            throw $e;
-        }
+        $this->db->insert(self::TABLE_NAME, []);
+        $this->model->setId((int) $this->db->lastInsertId());
     }
 
     /**


### PR DESCRIPTION
When you create a Pricing Rule with an name that already exists in the backend, a invalid Database entry is added. Therefore the admin interface is not loading the pricing rules anymore.

The reason is because the create() call is successfully but in the update() call you get an error because a pricing Rule with that name already exists. Solution -> wrap it into a transaction so both queries have to be executed successfully