### PR TITLE
Support for adjusting batch-size in ProcessUpdateIndexQueueCommand

### DIFF
--- a/src/Command/IndexService/ProcessUpdateIndexQueueCommand.php
+++ b/src/Command/IndexService/ProcessUpdateIndexQueueCommand.php
@@ -155,13 +155,28 @@ class ProcessUpdateIndexQueueCommand extends AbstractIndexServiceCommand
         return 'combined product ID rows in store table index';
     }
 
+    /** 
+     * index updates per child process
+     */
     protected function getSegmentSize(): int
     {
-        return 500; // index updates per child process
+        $segmentSize = 500;
+
+        if($this->input->hasOption('segment-size') && this->input->getOption('segment-size')) {
+            $segmentSize = (int)$this->input->getOption('segment-size');
+        }
+        
+        return $segmentSize; 
     }
 
     protected function getBatchSize(): int
     {
-        return $this->input->getOption('batch-size') ?: $this->getSegmentSize();
+        $batchSize = $this->getSegmentSize();
+
+        if($this->input->hasOption('batch-size') && this->input->getOption('batch-size')) {
+            $batchSize = (int)$this->input->getOption('batch-size');
+        }
+        
+        return $batchSize;
     }
 }

--- a/src/Command/IndexService/ProcessUpdateIndexQueueCommand.php
+++ b/src/Command/IndexService/ProcessUpdateIndexQueueCommand.php
@@ -164,5 +164,4 @@ class ProcessUpdateIndexQueueCommand extends AbstractIndexServiceCommand
     {
         return $this->input->getOption('batch-size') ?: $this->getSegmentSize();
     }
-    
 }

--- a/src/Command/IndexService/ProcessUpdateIndexQueueCommand.php
+++ b/src/Command/IndexService/ProcessUpdateIndexQueueCommand.php
@@ -159,4 +159,10 @@ class ProcessUpdateIndexQueueCommand extends AbstractIndexServiceCommand
     {
         return 500; // index updates per child process
     }
+
+    protected function getBatchSize(): int
+    {
+        return $this->input->getOption('batch-size') ?: $this->getSegmentSize();
+    }
+    
 }

--- a/src/Command/IndexService/ProcessUpdateIndexQueueCommand.php
+++ b/src/Command/IndexService/ProcessUpdateIndexQueueCommand.php
@@ -155,28 +155,28 @@ class ProcessUpdateIndexQueueCommand extends AbstractIndexServiceCommand
         return 'combined product ID rows in store table index';
     }
 
-    /** 
+    /**
      * index updates per child process
      */
     protected function getSegmentSize(): int
     {
         $segmentSize = 500;
 
-        if($this->input->hasOption('segment-size') && this->input->getOption('segment-size')) {
+        if ($this->input->hasOption('segment-size') && this->input->getOption('segment-size')) {
             $segmentSize = (int)$this->input->getOption('segment-size');
         }
-        
-        return $segmentSize; 
+
+        return $segmentSize;
     }
 
     protected function getBatchSize(): int
     {
         $batchSize = $this->getSegmentSize();
 
-        if($this->input->hasOption('batch-size') && this->input->getOption('batch-size')) {
+        if ($this->input->hasOption('batch-size') && this->input->getOption('batch-size')) {
             $batchSize = (int)$this->input->getOption('batch-size');
         }
-        
+
         return $batchSize;
     }
 }

--- a/src/Command/IndexService/ProcessUpdateIndexQueueCommand.php
+++ b/src/Command/IndexService/ProcessUpdateIndexQueueCommand.php
@@ -162,7 +162,7 @@ class ProcessUpdateIndexQueueCommand extends AbstractIndexServiceCommand
     {
         $segmentSize = 500;
 
-        if ($this->input->hasOption('segment-size') && this->input->getOption('segment-size')) {
+        if ($this->input->hasOption('segment-size') && $this->input->getOption('segment-size')) {
             $segmentSize = (int)$this->input->getOption('segment-size');
         }
 
@@ -173,7 +173,7 @@ class ProcessUpdateIndexQueueCommand extends AbstractIndexServiceCommand
     {
         $batchSize = $this->getSegmentSize();
 
-        if ($this->input->hasOption('batch-size') && this->input->getOption('batch-size')) {
+        if ($this->input->hasOption('batch-size') && $this->input->getOption('batch-size')) {
             $batchSize = (int)$this->input->getOption('batch-size');
         }
 


### PR DESCRIPTION
With this PR it gets possible to adjust the batch size using the existing command option.

Example: `bin/console ecommerce:indexservice:process-update-queue --timeout=5 --processes=3 --batch-size=50`

From the docs:

> The batch size is determined by getBatchSize() and defaults to the segment
 > size. The segment size is the number of items a worker (child) process
 >consumes before it dies. This means that, by default, a child process will
 > process all its items, persist them in a batch and then die. If you want
 > to improve the performance of your command, try to tweak getSegmentSize()
 >first. Optionally, you can tweak getBatchSize() to process multiple batches
 > in each child process.