### PR TITLE
Exclude filters in aggregations conditionally

### DIFF
--- a/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -872,6 +872,11 @@ abstract class AbstractElasticSearch implements ProductListInterface
         }
     }
 
+    protected function groupByValuesSpecificFilterExcludes(string $fieldname, array $config): array
+    {
+        return [];
+    }
+
     /**
      * loads all prepared group by values
      *   1 - get general filter (= filter of fields don't need to be considered in group by values or where fieldnameShouldBeExcluded set to false)
@@ -925,11 +930,13 @@ abstract class AbstractElasticSearch implements ProductListInterface
             //exclude all attributes that are already filtered
             $shortFieldname = $this->getTenantConfig()->getReverseMappedFieldName($fieldname);
 
+            $specificFilteredFieldnames = [...$filteredFieldnames, ...$this->groupByValuesSpecificFilterExcludes($fieldname, $config)];
+
             $specificFilters = [];
             //user specific filters
-            $specificFilters = $this->buildFilterConditions($specificFilters, array_merge($filteredFieldnames, [$shortFieldname => $shortFieldname]));
+            $specificFilters = $this->buildFilterConditions($specificFilters, array_merge($specificFilteredFieldnames, [$shortFieldname => $shortFieldname]));
             //relation conditions
-            $specificFilters = $this->buildRelationConditions($specificFilters, array_merge($filteredFieldnames, [$shortFieldname => $shortFieldname]));
+            $specificFilters = $this->buildRelationConditions($specificFilters, array_merge($specificFilteredFieldnames, [$shortFieldname => $shortFieldname]));
 
             if (!empty($config['aggregationConfig'])) {
                 $aggregation = $config['aggregationConfig'];

--- a/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -932,7 +932,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
 
             $specificFilteredFieldnames = [
                 ...$filteredFieldnames,
-                ...$this->groupByValuesSpecificFilterExcludes($fieldname, $config)
+                ...$this->groupByValuesSpecificFilterExcludes($fieldname, $config),
             ];
 
             $specificFilters = [];

--- a/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -930,13 +930,22 @@ abstract class AbstractElasticSearch implements ProductListInterface
             //exclude all attributes that are already filtered
             $shortFieldname = $this->getTenantConfig()->getReverseMappedFieldName($fieldname);
 
-            $specificFilteredFieldnames = [...$filteredFieldnames, ...$this->groupByValuesSpecificFilterExcludes($fieldname, $config)];
+            $specificFilteredFieldnames = [
+                ...$filteredFieldnames,
+                ...$this->groupByValuesSpecificFilterExcludes($fieldname, $config)
+            ];
 
             $specificFilters = [];
             //user specific filters
-            $specificFilters = $this->buildFilterConditions($specificFilters, array_merge($specificFilteredFieldnames, [$shortFieldname => $shortFieldname]));
+            $specificFilters = $this->buildFilterConditions(
+                $specificFilters,
+                array_merge($specificFilteredFieldnames, [$shortFieldname => $shortFieldname])
+            );
             //relation conditions
-            $specificFilters = $this->buildRelationConditions($specificFilters, array_merge($specificFilteredFieldnames, [$shortFieldname => $shortFieldname]));
+            $specificFilters = $this->buildRelationConditions(
+                $specificFilters,
+                array_merge($specificFilteredFieldnames, [$shortFieldname => $shortFieldname])
+            );
 
             if (!empty($config['aggregationConfig'])) {
                 $aggregation = $config['aggregationConfig'];

--- a/src/IndexService/ProductList/OpenSearch/AbstractOpenSearch.php
+++ b/src/IndexService/ProductList/OpenSearch/AbstractOpenSearch.php
@@ -929,7 +929,7 @@ abstract class AbstractOpenSearch implements ProductListInterface
 
             $specificFilteredFieldnames = [
                 ...$filteredFieldnames,
-                ...$this->groupByValuesSpecificFilterExcludes($fieldname, $config)
+                ...$this->groupByValuesSpecificFilterExcludes($fieldname, $config),
             ];
 
             $specificFilters = [];

--- a/src/IndexService/ProductList/OpenSearch/AbstractOpenSearch.php
+++ b/src/IndexService/ProductList/OpenSearch/AbstractOpenSearch.php
@@ -869,6 +869,11 @@ abstract class AbstractOpenSearch implements ProductListInterface
         }
     }
 
+    protected function groupByValuesSpecificFilterExcludes(string $fieldname, array $config): array
+    {
+        return [];
+    }
+
     /**
      * loads all prepared group by values
      *   1 - get general filter (= filter of fields don't need to be considered in group by values or where fieldnameShouldBeExcluded set to false)
@@ -922,11 +927,13 @@ abstract class AbstractOpenSearch implements ProductListInterface
             //exclude all attributes that are already filtered
             $shortFieldname = $this->getTenantConfig()->getReverseMappedFieldName($fieldname);
 
+            $specificFilteredFieldnames = [...$filteredFieldnames, ...$this->groupByValuesSpecificFilterExcludes($fieldname, $config)];
+
             $specificFilters = [];
             //user specific filters
-            $specificFilters = $this->buildFilterConditions($specificFilters, array_merge($filteredFieldnames, [$shortFieldname => $shortFieldname]));
+            $specificFilters = $this->buildFilterConditions($specificFilters, array_merge($specificFilteredFieldnames, [$shortFieldname => $shortFieldname]));
             //relation conditions
-            $specificFilters = $this->buildRelationConditions($specificFilters, array_merge($filteredFieldnames, [$shortFieldname => $shortFieldname]));
+            $specificFilters = $this->buildRelationConditions($specificFilters, array_merge($specificFilteredFieldnames, [$shortFieldname => $shortFieldname]));
 
             if (!empty($config['aggregationConfig'])) {
                 $aggregation = $config['aggregationConfig'];

--- a/src/IndexService/ProductList/OpenSearch/AbstractOpenSearch.php
+++ b/src/IndexService/ProductList/OpenSearch/AbstractOpenSearch.php
@@ -927,13 +927,22 @@ abstract class AbstractOpenSearch implements ProductListInterface
             //exclude all attributes that are already filtered
             $shortFieldname = $this->getTenantConfig()->getReverseMappedFieldName($fieldname);
 
-            $specificFilteredFieldnames = [...$filteredFieldnames, ...$this->groupByValuesSpecificFilterExcludes($fieldname, $config)];
+            $specificFilteredFieldnames = [
+                ...$filteredFieldnames,
+                ...$this->groupByValuesSpecificFilterExcludes($fieldname, $config)
+            ];
 
             $specificFilters = [];
             //user specific filters
-            $specificFilters = $this->buildFilterConditions($specificFilters, array_merge($specificFilteredFieldnames, [$shortFieldname => $shortFieldname]));
+            $specificFilters = $this->buildFilterConditions(
+                $specificFilters,
+                array_merge($specificFilteredFieldnames, [$shortFieldname => $shortFieldname])
+            );
             //relation conditions
-            $specificFilters = $this->buildRelationConditions($specificFilters, array_merge($specificFilteredFieldnames, [$shortFieldname => $shortFieldname]));
+            $specificFilters = $this->buildRelationConditions(
+                $specificFilters,
+                array_merge($specificFilteredFieldnames, [$shortFieldname => $shortFieldname])
+            );
 
             if (!empty($config['aggregationConfig'])) {
                 $aggregation = $config['aggregationConfig'];


### PR DESCRIPTION
This PR adds a method to exclude specific filters in the "groupByValues" logic.

There is no breaking change, its just extending the existing possibilities of adjusting the returned aggregation values.

**Example**:

I have 2 fields which are displayed as one filter in the frontend, lets say sale categories and regular categories. Now I want to exclude the category filter for the sale category filter and vice versa, but I do not want to exclude them for any other filter.

With the new function I now can do something like this:


```
    ...
    protected function groupByValuesSpecificFilterExcludes(string $fieldname, array $config): array
    {
        $currentShortFieldname = $this->getTenantConfig()->getReverseMappedFieldName($fieldname);

        // do not consider sale filters for category filter counts and vice versa
        return match ($currentShortFieldname) {
            $saleFieldName => [
                $categoriesFieldName => $categoriesFieldName
            ],
            $categoriesFieldName => [
                $saleFieldName => $saleFieldName
            ]
            default => []
        };
    }
```
