### PR TITLE
SelectCategory type error

### DIFF
--- a/src/FilterService/FilterType/ElasticSearch/SelectCategory.php
+++ b/src/FilterService/FilterType/ElasticSearch/SelectCategory.php
@@ -74,10 +74,9 @@ class SelectCategory extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
         }
 
         $currentFilter[$filterDefinition->getField()] = $value;
-        $value = (string)$value;
 
         if (!empty($value)) {
-            $value = trim($value);
+            $value = trim((string)$value);
             $productList->addCondition($value, $filterDefinition->getField());
         }
 

--- a/src/FilterService/FilterType/ElasticSearch/SelectCategory.php
+++ b/src/FilterService/FilterType/ElasticSearch/SelectCategory.php
@@ -74,6 +74,7 @@ class SelectCategory extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
         }
 
         $currentFilter[$filterDefinition->getField()] = $value;
+        $value = (string)$value;
 
         if (!empty($value)) {
             $value = trim($value);

--- a/src/FilterService/FilterType/SearchIndex/SelectCategory.php
+++ b/src/FilterService/FilterType/SearchIndex/SelectCategory.php
@@ -72,6 +72,8 @@ class SelectCategory extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
 
         $currentFilter[$filterDefinition->getField()] = $value;
 
+        $value = (string)$value;
+
         if (!empty($value)) {
             $value = trim($value);
             $productList->addCondition($value, $filterDefinition->getField());

--- a/src/FilterService/FilterType/SearchIndex/SelectCategory.php
+++ b/src/FilterService/FilterType/SearchIndex/SelectCategory.php
@@ -72,10 +72,8 @@ class SelectCategory extends \Pimcore\Bundle\EcommerceFrameworkBundle\FilterServ
 
         $currentFilter[$filterDefinition->getField()] = $value;
 
-        $value = (string)$value;
-
         if (!empty($value)) {
-            $value = trim($value);
+            $value = trim((string)$value);
             $productList->addCondition($value, $filterDefinition->getField());
         }
 


### PR DESCRIPTION
In php 8.2 there is an error for the `trim()` function when passing something different than a string, in this case an data object id.