### PR TITLE
Fix boolean types in ProductList::addCondition()

### DIFF
--- a/doc/03_Installation/01_Upgrade_Notes.md
+++ b/doc/03_Installation/01_Upgrade_Notes.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 
+#### v2.0.0
+Added `bool` as possible type to `$condition` parameter of `addCondition` function in `ProductListInterface` (and all implementing classes).
+
 #### v1.2.1
 - Removed the package "rybakit/twig-deferred-extension". If you extend the twig layout from the E-Commerce Framework, 
   please check if custom CSS/JS code added by `pimcore_head_script` and `pimcore_head_link` is still working. 

--- a/src/IndexService/ProductList/DefaultFindologic.php
+++ b/src/IndexService/ProductList/DefaultFindologic.php
@@ -109,7 +109,7 @@ class DefaultFindologic implements ProductListInterface
         return $this->products;
     }
 
-    public function addCondition(array|string $condition, string $fieldname = ''): void
+    public function addCondition(array|string|bool $condition, string $fieldname = ''): void
     {
         $this->products = null;
         $this->conditions[$fieldname][] = $condition;

--- a/src/IndexService/ProductList/DefaultMysql.php
+++ b/src/IndexService/ProductList/DefaultMysql.php
@@ -87,7 +87,7 @@ class DefaultMysql implements ProductListInterface
 
     protected ?float $conditionPriceTo = null;
 
-    public function addCondition(array|string $condition, string $fieldname = ''): void
+    public function addCondition(array|string|bool $condition, string $fieldname = ''): void
     {
         $this->products = null;
         $this->conditions[$fieldname][] = $condition;

--- a/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -169,7 +169,7 @@ abstract class AbstractElasticSearch implements ProductListInterface
      *
      * @param string $fieldname - must be set for elastic search
      */
-    public function addCondition(array|string $condition, string $fieldname = ''): void
+    public function addCondition(array|string|bool $condition, string $fieldname = ''): void
     {
         $this->filterConditions[$fieldname][] = $condition;
         $this->preparedGroupByValuesLoaded = false;

--- a/src/IndexService/ProductList/OpenSearch/AbstractOpenSearch.php
+++ b/src/IndexService/ProductList/OpenSearch/AbstractOpenSearch.php
@@ -166,7 +166,7 @@ abstract class AbstractOpenSearch implements ProductListInterface
      *
      * @param string $fieldname - must be set for elastic search
      */
-    public function addCondition(array|string $condition, string $fieldname = ''): void
+    public function addCondition(array|string|bool $condition, string $fieldname = ''): void
     {
         $this->filterConditions[$fieldname][] = $condition;
         $this->preparedGroupByValuesLoaded = false;

--- a/src/IndexService/ProductList/ProductListInterface.php
+++ b/src/IndexService/ProductList/ProductListInterface.php
@@ -68,7 +68,7 @@ interface ProductListInterface extends PaginateListingInterface
      * and exclude functionality in group by results
      *
      */
-    public function addCondition(array|string $condition, string $fieldname = ''): void;
+    public function addCondition(array|string|bool $condition, string $fieldname = ''): void;
 
     /**
      * Adds query condition to product list for fulltext search


### PR DESCRIPTION
Shorthand addCondition() for boolean fields in OpenSearch or ElasticSearch currently result in an error, as the boolean value gets auto converted to string "1".

> {"error":{"root_cause":[{"type":"query_shard_exception","reason":"failed to create query: **Can't parse boolean value [1], expected [true] or [false]**","index":"assortment_de-0","index_uuid":"aVjoKkAaRhCpiHy0515nOA"}],"type":"search_phase_execution_exception","reason":"all shards failed","phase":"query","grouped":true,"failed_shards":[{"shard":0,"index":"assortment_de-0","node":"R8dCIDExT-2ABMPjIQ-M2w","reason":{"type":"query_shard_exception","reason":"failed to create query: Can't parse boolean value [1], expected [true] or [false]","index":"assortment_de-0","index_uuid":"aVjoKkAaRhCpiHy0515nOA","caused_by":{"type":"illegal_argument_exception","reason":"Can't parse boolean value [1], expected [true] or [false]"}}}]},"status":400}

This PR fixes the typing error (introducing a BC break).

### Steps to reproduce
1. add boolean field to index config
2. filter by boolean field using `productList->addCondition($boolValue, $fieldName);
3. Query productlist will result in the error above


### Workaround 
Pass the strings "true" or "false" in the `addCondition()` call, as it gets converted to bool values in the query later on.