### PR TITLE
[Improvement]: Support Dbal 4

### DIFF
--- a/src/OrderManager/Order/Listing.php
+++ b/src/OrderManager/Order/Listing.php
@@ -208,9 +208,9 @@ class Listing extends AbstractOrderList implements OrderListInterface
     {
         $queryBuilder = $this->getQueryBuilder();
 
-        $alias = '';
+        $alias = 'customer';
         if (!$this->aliasExistsInFrom($queryBuilder, $alias)) {
-            $queryBuilder->join('`order`', 'object_' . $classId, 'customer',
+            $queryBuilder->join('`order`', 'object_' . $classId, $alias,
                 'customer.id = order.customer__id'
             );
         }

--- a/src/OrderManager/Order/Listing.php
+++ b/src/OrderManager/Order/Listing.php
@@ -16,14 +16,15 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager\Order;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Query\QueryBuilder as DoctrineQueryBuilder;
-use Doctrine\DBAL\Query\QueryException;
 use Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager\AbstractOrderList;
 use Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager\OrderListFilterInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager\OrderListInterface;
 use Pimcore\Db;
 use Pimcore\Model\DataObject\OnlineShopOrder;
 use Pimcore\Model\DataObject\OnlineShopOrderItem;
+use ReflectionClass;
 
 class Listing extends AbstractOrderList implements OrderListInterface
 {
@@ -107,36 +108,25 @@ class Listing extends AbstractOrderList implements OrderListInterface
         return $this;
     }
 
+    private function aliasExistsInFrom(QueryBuilder $queryBuilder, string $alias): bool
+    {
+        $reflector = new ReflectionClass($queryBuilder);
+        $from = $reflector->getProperty('from')->getValue($queryBuilder);
+        return array_key_exists($alias, $from);
+    }
+
     public function joinPricingRule(): static
     {
         $queryBuilder = $this->getQueryBuilder();
         $alias = 'pricingRule';
-
-        try {
-            $clonedQueryBuilder = clone $queryBuilder;
-            $clonedQueryBuilder->leftJoin(
+        if (!$this->aliasExistsInFrom($queryBuilder, $alias)) {
+            $queryBuilder->leftJoin(
                 'orderItem',
                 'object_collection_PricingRule_' . OnlineShopOrderItem::classId(),
                 $alias,
                 'pricingRule.id = orderItem.id AND pricingRule.fieldname = "pricingRules"'
             );
-            $clonedQueryBuilder->getSQL();
-        } catch (QueryException $exception) {
-            if (str_contains(
-                $exception->getMessage(),
-                'The given alias \''.$alias.'\' is not unique in FROM and JOIN clause table',
-            )
-            ) {
-                return $this;
-            }
         }
-
-        $queryBuilder->leftJoin(
-            'orderItem',
-            'object_collection_PricingRule_' . OnlineShopOrderItem::classId(),
-            $alias,
-            'pricingRule.id = orderItem.id AND pricingRule.fieldname = "pricingRules"'
-        );
 
         return $this;
     }
@@ -145,12 +135,15 @@ class Listing extends AbstractOrderList implements OrderListInterface
     {
         $queryBuilder = $this->getQueryBuilder();
 
-        $queryBuilder->leftJoin(
-            '`order`',
-            'object_collection_OrderPriceModifications_' . OnlineShopOrder::classId(),
-            'OrderPriceModifications',
-            'OrderPriceModifications.id = order.oo_id AND OrderPriceModifications.fieldname = "priceModifications"'
-        );
+        $alias = 'OrderPriceModifications';
+        if (!$this->aliasExistsInFrom($queryBuilder, $alias)) {
+            $queryBuilder->leftJoin(
+                '`order`',
+                'object_collection_OrderPriceModifications_' . OnlineShopOrder::classId(),
+                $alias,
+                'OrderPriceModifications.id = order.oo_id AND OrderPriceModifications.fieldname = "priceModifications"'
+            );
+        }
 
         return $this;
     }
@@ -162,12 +155,15 @@ class Listing extends AbstractOrderList implements OrderListInterface
         // create sub select
         $paymentQueryBuilder = Db::getConnection()->createQueryBuilder();
 
-        $paymentQueryBuilder->select('GROUP_CONCAT(",", _paymentInfo.paymentReference, "," SEPARATOR ",") AS paymentReference', '_order.id AS id')
-            ->from('object_collection_PaymentInfo_' . OnlineShopOrder::classId(), '_paymentInfo')
-            ->join('_paymentInfo', 'object_' . OnlineShopOrder::classId(), '_order', '_order.oo_id = _paymentInfo.id');
+        $alias = 'paymentInfo';
+        if (!$this->aliasExistsInFrom($queryBuilder, $alias)) {
+            $paymentQueryBuilder->select('GROUP_CONCAT(",", _paymentInfo.paymentReference, "," SEPARATOR ",") AS paymentReference', '_order.id AS id')
+                ->from('object_collection_PaymentInfo_' . OnlineShopOrder::classId(), '_paymentInfo')
+                ->join('_paymentInfo', 'object_' . OnlineShopOrder::classId(), '_order', '_order.oo_id = _paymentInfo.id');
 
-        // join
-        $queryBuilder->leftJoin('`order`', (string) $paymentQueryBuilder, 'paymentInfo', 'paymentInfo.id = `order`.oo_id');
+            // join
+            $queryBuilder->leftJoin('`order`', (string)$paymentQueryBuilder, $alias, 'paymentInfo.id = `order`.oo_id');
+        }
 
         return $this;
     }
@@ -176,8 +172,11 @@ class Listing extends AbstractOrderList implements OrderListInterface
     {
         $queryBuilder = $this->getQueryBuilder();
 
-        $queryBuilder->join('orderItem', 'objects', 'orderItemObjects',
-            'orderItemObjects.id = orderItem.product__id');
+        $alias = 'orderItemObjects';
+        if (!$this->aliasExistsInFrom($queryBuilder, $alias)) {
+            $queryBuilder->join('orderItem', 'objects', $alias,
+                'orderItemObjects.id = orderItem.product__id');
+        }
 
         return $this;
     }
@@ -186,12 +185,15 @@ class Listing extends AbstractOrderList implements OrderListInterface
     {
         $queryBuilder = $this->getQueryBuilder();
 
-        $queryBuilder->join(
-            'orderItem',
-            'object_query_' . $classId,
-            'product',
-            'product.oo_id = orderItem.product__id'
-        );
+        $alias = 'product';
+        if (!$this->aliasExistsInFrom($queryBuilder, $alias)) {
+            $queryBuilder->join(
+                'orderItem',
+                'object_query_' . $classId,
+                $alias,
+                'product.oo_id = orderItem.product__id'
+            );
+        }
 
         return $this;
     }
@@ -206,9 +208,12 @@ class Listing extends AbstractOrderList implements OrderListInterface
     {
         $queryBuilder = $this->getQueryBuilder();
 
-        $queryBuilder->join('`order`', 'object_' . $classId, 'customer',
-            'customer.id = order.customer__id'
-        );
+        $alias = '';
+        if (!$this->aliasExistsInFrom($queryBuilder, $alias)) {
+            $queryBuilder->join('`order`', 'object_' . $classId, 'customer',
+                'customer.id = order.customer__id'
+            );
+        }
 
         return $this;
     }

--- a/src/OrderManager/Order/Listing.php
+++ b/src/OrderManager/Order/Listing.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager\Order;
 
 use Doctrine\DBAL\Query\QueryBuilder as DoctrineQueryBuilder;
+use Doctrine\DBAL\Query\QueryException;
 use Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager\AbstractOrderList;
 use Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager\OrderListFilterInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager\OrderListInterface;
@@ -106,18 +107,29 @@ class Listing extends AbstractOrderList implements OrderListInterface
         return $this;
     }
 
+
     public function joinPricingRule(): static
     {
         $queryBuilder = $this->getQueryBuilder();
-        $joins = $queryBuilder->getQueryPart('from');
+        $alias = 'pricingRule';
 
-        if (!array_key_exists('pricingRule', $joins)) {
-            $queryBuilder->leftJoin(
+        try {
+            $clonedQueryBuilder = clone $queryBuilder;
+            $clonedQueryBuilder->leftJoin(
                 'orderItem',
                 'object_collection_PricingRule_' . OnlineShopOrderItem::classId(),
-                'pricingRule',
+                $alias,
                 'pricingRule.id = orderItem.id AND pricingRule.fieldname = "pricingRules"'
             );
+            $clonedQueryBuilder->getSQL();
+        } catch (QueryException $exception){
+            if (str_contains(
+                    $exception->getMessage(),
+                    'The given alias \''.$alias.'\' is not unique in FROM and JOIN clause table',
+                )
+            ){
+                return $this;
+            }
         }
 
         return $this;
@@ -127,16 +139,12 @@ class Listing extends AbstractOrderList implements OrderListInterface
     {
         $queryBuilder = $this->getQueryBuilder();
 
-        $joins = $queryBuilder->getQueryPart('from');
-
-        if (!array_key_exists('OrderPriceModifications', $joins)) {
-            $queryBuilder->leftJoin(
-                '`order`',
-                'object_collection_OrderPriceModifications_' . OnlineShopOrder::classId(),
-                'OrderPriceModifications',
-                'OrderPriceModifications.id = order.oo_id AND OrderPriceModifications.fieldname = "priceModifications"'
-            );
-        }
+        $queryBuilder->leftJoin(
+            '`order`',
+            'object_collection_OrderPriceModifications_' . OnlineShopOrder::classId(),
+            'OrderPriceModifications',
+            'OrderPriceModifications.id = order.oo_id AND OrderPriceModifications.fieldname = "priceModifications"'
+        );
 
         return $this;
     }
@@ -145,19 +153,15 @@ class Listing extends AbstractOrderList implements OrderListInterface
     {
         $queryBuilder = $this->getQueryBuilder();
 
-        $joins = $queryBuilder->getQueryPart('from');
+        // create sub select
+        $paymentQueryBuilder = Db::getConnection()->createQueryBuilder();
 
-        if (!array_key_exists('paymentInfo', $joins)) {
-            // create sub select
-            $paymentQueryBuilder = Db::getConnection()->createQueryBuilder();
+        $paymentQueryBuilder->select('GROUP_CONCAT(",", _paymentInfo.paymentReference, "," SEPARATOR ",") AS paymentReference', '_order.id AS id')
+            ->from('object_collection_PaymentInfo_' . OnlineShopOrder::classId(), '_paymentInfo')
+            ->join('_paymentInfo', 'object_' . OnlineShopOrder::classId(), '_order', '_order.oo_id = _paymentInfo.id');
 
-            $paymentQueryBuilder->select('GROUP_CONCAT(",", _paymentInfo.paymentReference, "," SEPARATOR ",") AS paymentReference', '_order.id AS id')
-                ->from('object_collection_PaymentInfo_' . OnlineShopOrder::classId(), '_paymentInfo')
-                ->join('_paymentInfo', 'object_' . OnlineShopOrder::classId(), '_order', '_order.oo_id = _paymentInfo.id');
-
-            // join
-            $queryBuilder->leftJoin('`order`', (string) $paymentQueryBuilder, 'paymentInfo', 'paymentInfo.id = `order`.oo_id');
-        }
+        // join
+        $queryBuilder->leftJoin('`order`', (string) $paymentQueryBuilder, 'paymentInfo', 'paymentInfo.id = `order`.oo_id');
 
         return $this;
     }
@@ -166,12 +170,8 @@ class Listing extends AbstractOrderList implements OrderListInterface
     {
         $queryBuilder = $this->getQueryBuilder();
 
-        $joins = $queryBuilder->getQueryPart('from');
-
-        if (!array_key_exists('orderItemObjects', $joins)) {
-            $queryBuilder->join('orderItem', 'objects', 'orderItemObjects',
-                'orderItemObjects.id = orderItem.product__id');
-        }
+        $queryBuilder->join('orderItem', 'objects', 'orderItemObjects',
+            'orderItemObjects.id = orderItem.product__id');
 
         return $this;
     }
@@ -180,16 +180,12 @@ class Listing extends AbstractOrderList implements OrderListInterface
     {
         $queryBuilder = $this->getQueryBuilder();
 
-        $joins = $queryBuilder->getQueryPart('from');
-
-        if (!array_key_exists('product', $joins)) {
-            $queryBuilder->join(
-                'orderItem',
-                'object_query_' . $classId,
-                'product',
-                'product.oo_id = orderItem.product__id'
-            );
-        }
+        $queryBuilder->join(
+            'orderItem',
+            'object_query_' . $classId,
+            'product',
+            'product.oo_id = orderItem.product__id'
+        );
 
         return $this;
     }
@@ -204,13 +200,9 @@ class Listing extends AbstractOrderList implements OrderListInterface
     {
         $queryBuilder = $this->getQueryBuilder();
 
-        $joins = $queryBuilder->getQueryPart('from');
-
-        if (!array_key_exists('customer', $joins)) {
-            $queryBuilder->join('`order`', 'object_' . $classId, 'customer',
-                'customer.id = order.customer__id'
-            );
-        }
+        $queryBuilder->join('`order`', 'object_' . $classId, 'customer',
+            'customer.id = order.customer__id'
+        );
 
         return $this;
     }

--- a/src/OrderManager/Order/Listing.php
+++ b/src/OrderManager/Order/Listing.php
@@ -112,6 +112,7 @@ class Listing extends AbstractOrderList implements OrderListInterface
     {
         $reflector = new ReflectionClass($queryBuilder);
         $from = $reflector->getProperty('from')->getValue($queryBuilder);
+
         return array_key_exists($alias, $from);
     }
 

--- a/src/OrderManager/Order/Listing.php
+++ b/src/OrderManager/Order/Listing.php
@@ -107,7 +107,6 @@ class Listing extends AbstractOrderList implements OrderListInterface
         return $this;
     }
 
-
     public function joinPricingRule(): static
     {
         $queryBuilder = $this->getQueryBuilder();
@@ -122,12 +121,12 @@ class Listing extends AbstractOrderList implements OrderListInterface
                 'pricingRule.id = orderItem.id AND pricingRule.fieldname = "pricingRules"'
             );
             $clonedQueryBuilder->getSQL();
-        } catch (QueryException $exception){
+        } catch (QueryException $exception) {
             if (str_contains(
-                    $exception->getMessage(),
-                    'The given alias \''.$alias.'\' is not unique in FROM and JOIN clause table',
-                )
-            ){
+                $exception->getMessage(),
+                'The given alias \''.$alias.'\' is not unique in FROM and JOIN clause table',
+            )
+            ) {
                 return $this;
             }
         }

--- a/src/OrderManager/Order/Listing.php
+++ b/src/OrderManager/Order/Listing.php
@@ -131,6 +131,13 @@ class Listing extends AbstractOrderList implements OrderListInterface
             }
         }
 
+        $queryBuilder->leftJoin(
+            'orderItem',
+            'object_collection_PricingRule_' . OnlineShopOrderItem::classId(),
+            $alias,
+            'pricingRule.id = orderItem.id AND pricingRule.fieldname = "pricingRules"'
+        );
+
         return $this;
     }
 

--- a/src/OrderManager/Order/Listing.php
+++ b/src/OrderManager/Order/Listing.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager\Order;
 
-use Doctrine\DBAL\Query\QueryBuilder;
 use Doctrine\DBAL\Query\QueryBuilder as DoctrineQueryBuilder;
 use Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager\AbstractOrderList;
 use Pimcore\Bundle\EcommerceFrameworkBundle\OrderManager\OrderListFilterInterface;
@@ -108,7 +107,7 @@ class Listing extends AbstractOrderList implements OrderListInterface
         return $this;
     }
 
-    private function aliasExistsInFrom(QueryBuilder $queryBuilder, string $alias): bool
+    private function aliasExistsInFrom(DoctrineQueryBuilder $queryBuilder, string $alias): bool
     {
         $reflector = new ReflectionClass($queryBuilder);
         $from = $reflector->getProperty('from')->getValue($queryBuilder);


### PR DESCRIPTION
Related to https://github.com/pimcore/pimcore/pull/18150

~Might not need to check if the JOIN is already present , could be some legacy leftover.
In case, if we are unable to use getQueryPart `from`, then we could try to catch the exception thrown when trying to join a table with an existing alias (hence already performed the same join with hardcoded alias at least once)~
Realized it check the FROM part, so to avoid joining table A with from A,B,C or so?

![image](https://github.com/user-attachments/assets/ff79727c-a371-44ee-8188-c9e45f137b07)
