### PR TITLE
Fix: switch index alias requires opensearch admin privileges

### DIFF
--- a/src/IndexService/Worker/OpenSearch/AbstractOpenSearch.php
+++ b/src/IndexService/Worker/OpenSearch/AbstractOpenSearch.php
@@ -504,7 +504,7 @@ abstract class AbstractOpenSearch extends ProductCentricBatchProcessingWorker
             'actions' => [
                 [
                     'remove' => [
-                        'index' => '*',
+                        'index' => $this->indexName . '-*',
                         'alias' => $this->indexName,
                     ],
                 ],
@@ -529,7 +529,7 @@ abstract class AbstractOpenSearch extends ProductCentricBatchProcessingWorker
     protected function cleanupUnusedEsIndices(): void
     {
         $osClient = $this->getOpenSearchClient();
-        $stats = $osClient->indices()->stats();
+        $stats = $osClient->indices()->stats(['index' => $this->indexName . '-*']);
         foreach ($stats['indices'] as $key => $data) {
             preg_match('/'.$this->indexName.'-(\d+)/', $key, $matches);
             if (is_array($matches) && count($matches) > 1) {


### PR DESCRIPTION
We want to use a non admin user for Pimcore, but OpenSearch `updateAliases` `remove` `*` requires admin privileges. Without them, OpenSearch logs the following: `... [WARN ][o.o.s.p.SystemIndexAccessEvaluator] [search-masters-0] indices:admin/aliases for '_all' indices is not allowed for a regular user`. It is not necessary to remove all indexes. `indexName-*"`is sufficient because indexes are named `indexName-number`.

Second, this change also changes `stats` to use this wildcard. This allows OpenSearch permissions to be given on `indexName*` instead of to all indexes.

These changes probably apply to ElasticSearch as well, but I have not tested that.