### PR TITLE
[Bug] Added index to cartId

### DIFF
--- a/src/Resources/install/class_sources/class_OnlineShopOrder_export.json
+++ b/src/Resources/install/class_sources/class_OnlineShopOrder_export.json
@@ -594,7 +594,7 @@
                                         "tooltip": "",
                                         "mandatory": false,
                                         "noteditable": true,
-                                        "index": false,
+                                        "index": true,
                                         "locked": false,
                                         "style": "",
                                         "permissions": null,


### PR DESCRIPTION
missing index definition in class definition of online shop order class. 

related to https://github.com/pimcore/ecommerce-framework-bundle/issues/242