### PR TITLE
Add missing `getConditionVariables()` calls to listing DAOs

### DIFF
--- a/src/CartManager/Cart/Listing/Dao.php
+++ b/src/CartManager/Cart/Listing/Dao.php
@@ -28,7 +28,8 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         $carts = [];
         $cartIds = $this->db->fetchFirstColumn(
-            'SELECT id FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
+            'SELECT id FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME
+            . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
             $this->model->getConditionVariables(),
         );
 
@@ -45,7 +46,8 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne(
-                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME . '`' . $this->getCondition(),
+                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME
+                . '`' . $this->getCondition(),
                 $this->model->getConditionVariables(),
             );
         } catch (\Exception $e) {

--- a/src/CartManager/Cart/Listing/Dao.php
+++ b/src/CartManager/Cart/Listing/Dao.php
@@ -28,7 +28,8 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         $carts = [];
         $cartIds = $this->db->fetchFirstColumn(
-            'SELECT id FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME
+            'SELECT id FROM '
+            . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME
             . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
             $this->model->getConditionVariables(),
         );
@@ -46,7 +47,8 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne(
-                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME
+                'SELECT COUNT(*) FROM `'
+                . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME
                 . '`' . $this->getCondition(),
                 $this->model->getConditionVariables(),
             );

--- a/src/CartManager/Cart/Listing/Dao.php
+++ b/src/CartManager/Cart/Listing/Dao.php
@@ -28,7 +28,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         $carts = [];
         $cartIds = $this->db->fetchFirstColumn(
-            'SELECT id FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), 
+            'SELECT id FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
             $this->model->getConditionVariables(),
         );
 
@@ -45,7 +45,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne(
-                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME . '`' . $this->getCondition(), 
+                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME . '`' . $this->getCondition(),
                 $this->model->getConditionVariables(),
             );
         } catch (\Exception $e) {

--- a/src/CartManager/Cart/Listing/Dao.php
+++ b/src/CartManager/Cart/Listing/Dao.php
@@ -27,8 +27,10 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     public function load(): array
     {
         $carts = [];
-        $cartIds = $this->db->fetchFirstColumn('SELECT id FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME .
-                                                 $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $cartIds = $this->db->fetchFirstColumn(
+            'SELECT id FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), 
+            $this->model->getConditionVariables(),
+        );
 
         foreach ($cartIds as $id) {
             $carts[] = call_user_func([$this->getCartClass(), 'getById'], $id);
@@ -42,7 +44,10 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME . '`' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne(
+                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME . '`' . $this->getCondition(), 
+                $this->model->getConditionVariables(),
+            );
         } catch (\Exception $e) {
             return 0;
         }

--- a/src/CartManager/Cart/Listing/Dao.php
+++ b/src/CartManager/Cart/Listing/Dao.php
@@ -28,7 +28,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         $carts = [];
         $cartIds = $this->db->fetchFirstColumn('SELECT id FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME .
-                                                 $this->getCondition() . $this->getOrder() . $this->getOffsetLimit());
+                                                 $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
 
         foreach ($cartIds as $id) {
             $carts[] = call_user_func([$this->getCartClass(), 'getById'], $id);
@@ -42,7 +42,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME . '`' . $this->getCondition());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME . '`' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
             return 0;
         }

--- a/src/CartManager/CartCheckoutData/Listing/Dao.php
+++ b/src/CartManager/CartCheckoutData/Listing/Dao.php
@@ -28,8 +28,10 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         $items = [];
 
-        $cartCheckoutDataItems = $this->db->fetchAllAssociative('SELECT cartid, `key` FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME .
-                                                 $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $cartCheckoutDataItems = $this->db->fetchAllAssociative(
+            'SELECT cartid, `key` FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), 
+            $this->model->getConditionVariables(),
+        );
 
         foreach ($cartCheckoutDataItems as $item) {
             $items[] = \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData::getByKeyCartId($item['key'], $item['cartid']);
@@ -42,7 +44,10 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int)$this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME . '`' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int)$this->db->fetchOne(
+                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME . '`' . $this->getCondition(), 
+                $this->model->getConditionVariables(),
+            );
         } catch (\Exception $e) {
             return 0;
         }

--- a/src/CartManager/CartCheckoutData/Listing/Dao.php
+++ b/src/CartManager/CartCheckoutData/Listing/Dao.php
@@ -29,7 +29,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
         $items = [];
 
         $cartCheckoutDataItems = $this->db->fetchAllAssociative(
-            'SELECT cartid, `key` FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), 
+            'SELECT cartid, `key` FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
             $this->model->getConditionVariables(),
         );
 
@@ -45,7 +45,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         try {
             return (int)$this->db->fetchOne(
-                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME . '`' . $this->getCondition(), 
+                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME . '`' . $this->getCondition(),
                 $this->model->getConditionVariables(),
             );
         } catch (\Exception $e) {

--- a/src/CartManager/CartCheckoutData/Listing/Dao.php
+++ b/src/CartManager/CartCheckoutData/Listing/Dao.php
@@ -29,7 +29,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
         $items = [];
 
         $cartCheckoutDataItems = $this->db->fetchAllAssociative('SELECT cartid, `key` FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME .
-                                                 $this->getCondition() . $this->getOrder() . $this->getOffsetLimit());
+                                                 $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
 
         foreach ($cartCheckoutDataItems as $item) {
             $items[] = \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData::getByKeyCartId($item['key'], $item['cartid']);
@@ -42,7 +42,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int)$this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME . '`' . $this->getCondition());
+            return (int)$this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME . '`' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
             return 0;
         }

--- a/src/CartManager/CartCheckoutData/Listing/Dao.php
+++ b/src/CartManager/CartCheckoutData/Listing/Dao.php
@@ -29,7 +29,8 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
         $items = [];
 
         $cartCheckoutDataItems = $this->db->fetchAllAssociative(
-            'SELECT cartid, `key` FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME
+            'SELECT cartid, `key` FROM '
+            . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME
             . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
             $this->model->getConditionVariables(),
         );
@@ -46,8 +47,9 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         try {
             return (int)$this->db->fetchOne(
-                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME . '`'
-                . $this->getCondition(),
+                'SELECT COUNT(*) FROM `'
+                . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME
+                . '`' . $this->getCondition(),
                 $this->model->getConditionVariables(),
             );
         } catch (\Exception $e) {

--- a/src/CartManager/CartCheckoutData/Listing/Dao.php
+++ b/src/CartManager/CartCheckoutData/Listing/Dao.php
@@ -29,7 +29,8 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
         $items = [];
 
         $cartCheckoutDataItems = $this->db->fetchAllAssociative(
-            'SELECT cartid, `key` FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
+            'SELECT cartid, `key` FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME
+            . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
             $this->model->getConditionVariables(),
         );
 
@@ -45,7 +46,8 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         try {
             return (int)$this->db->fetchOne(
-                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME . '`' . $this->getCondition(),
+                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME . '`'
+                . $this->getCondition(),
                 $this->model->getConditionVariables(),
             );
         } catch (\Exception $e) {

--- a/src/CartManager/CartItem/Listing/Dao.php
+++ b/src/CartManager/CartItem/Listing/Dao.php
@@ -28,7 +28,8 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         $items = [];
         $cartItems = $this->db->fetchAllAssociative(
-            'SELECT cartid, itemKey, parentItemKey FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
+            'SELECT cartid, itemKey, parentItemKey FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME
+            . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
             $this->model->getConditionVariables(),
         );
 
@@ -44,7 +45,8 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         try {
             return (int)$this->db->fetchOne(
-                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`' . $this->getCondition(),
+                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`'
+                . $this->getCondition(),
                 $this->model->getConditionVariables(),
             );
         } catch (\Exception $e) {
@@ -55,7 +57,8 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     public function getTotalAmount(): int
     {
         return (int)$this->db->fetchOne(
-            'SELECT SUM(count) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`' . $this->getCondition(),
+            'SELECT SUM(count) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`'
+            . $this->getCondition(),
             $this->model->getConditionVariables(),
         );
     }

--- a/src/CartManager/CartItem/Listing/Dao.php
+++ b/src/CartManager/CartItem/Listing/Dao.php
@@ -28,7 +28,8 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         $items = [];
         $cartItems = $this->db->fetchAllAssociative(
-            'SELECT cartid, itemKey, parentItemKey FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME
+            'SELECT cartid, itemKey, parentItemKey FROM '
+            . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME
             . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
             $this->model->getConditionVariables(),
         );
@@ -45,8 +46,9 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         try {
             return (int)$this->db->fetchOne(
-                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`'
-                . $this->getCondition(),
+                'SELECT COUNT(*) FROM `'
+                . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME
+                . '`' . $this->getCondition(),
                 $this->model->getConditionVariables(),
             );
         } catch (\Exception $e) {
@@ -57,8 +59,9 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     public function getTotalAmount(): int
     {
         return (int)$this->db->fetchOne(
-            'SELECT SUM(count) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`'
-            . $this->getCondition(),
+            'SELECT SUM(count) FROM `'
+            . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME
+            . '`' . $this->getCondition(),
             $this->model->getConditionVariables(),
         );
     }

--- a/src/CartManager/CartItem/Listing/Dao.php
+++ b/src/CartManager/CartItem/Listing/Dao.php
@@ -28,7 +28,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         $items = [];
         $cartItems = $this->db->fetchAllAssociative(
-            'SELECT cartid, itemKey, parentItemKey FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), 
+            'SELECT cartid, itemKey, parentItemKey FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
             $this->model->getConditionVariables(),
         );
 
@@ -44,7 +44,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         try {
             return (int)$this->db->fetchOne(
-                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`' . $this->getCondition(), 
+                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`' . $this->getCondition(),
                 $this->model->getConditionVariables(),
             );
         } catch (\Exception $e) {
@@ -55,7 +55,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     public function getTotalAmount(): int
     {
         return (int)$this->db->fetchOne(
-            'SELECT SUM(count) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`' . $this->getCondition(), 
+            'SELECT SUM(count) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`' . $this->getCondition(),
             $this->model->getConditionVariables(),
         );
     }

--- a/src/CartManager/CartItem/Listing/Dao.php
+++ b/src/CartManager/CartItem/Listing/Dao.php
@@ -28,7 +28,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         $items = [];
         $cartItems = $this->db->fetchAllAssociative('SELECT cartid, itemKey, parentItemKey FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME .
-                                                 $this->getCondition() . $this->getOrder() . $this->getOffsetLimit());
+                                                 $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
 
         foreach ($cartItems as $item) {
             $items[] = call_user_func([$this->getClassName(), 'getByCartIdItemKey'], $item['cartid'], $item['itemKey'], $item['parentItemKey']);
@@ -41,7 +41,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int)$this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`' . $this->getCondition());
+            return (int)$this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
             return 0;
         }
@@ -49,7 +49,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
 
     public function getTotalAmount(): int
     {
-        return (int)$this->db->fetchOne('SELECT SUM(count) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`' . $this->getCondition());
+        return (int)$this->db->fetchOne('SELECT SUM(count) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`' . $this->getCondition(), $this->model->getConditionVariables());
     }
 
     public function setClassName(string $className): void

--- a/src/CartManager/CartItem/Listing/Dao.php
+++ b/src/CartManager/CartItem/Listing/Dao.php
@@ -27,8 +27,10 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     public function load(): array
     {
         $items = [];
-        $cartItems = $this->db->fetchAllAssociative('SELECT cartid, itemKey, parentItemKey FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME .
-                                                 $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $cartItems = $this->db->fetchAllAssociative(
+            'SELECT cartid, itemKey, parentItemKey FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), 
+            $this->model->getConditionVariables(),
+        );
 
         foreach ($cartItems as $item) {
             $items[] = call_user_func([$this->getClassName(), 'getByCartIdItemKey'], $item['cartid'], $item['itemKey'], $item['parentItemKey']);
@@ -41,7 +43,10 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int)$this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int)$this->db->fetchOne(
+                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`' . $this->getCondition(), 
+                $this->model->getConditionVariables(),
+            );
         } catch (\Exception $e) {
             return 0;
         }
@@ -49,7 +54,10 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
 
     public function getTotalAmount(): int
     {
-        return (int)$this->db->fetchOne('SELECT SUM(count) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`' . $this->getCondition(), $this->model->getConditionVariables());
+        return (int)$this->db->fetchOne(
+            'SELECT SUM(count) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME . '`' . $this->getCondition(), 
+            $this->model->getConditionVariables(),
+        );
     }
 
     public function setClassName(string $className): void

--- a/src/PricingManager/Rule/Listing/Dao.php
+++ b/src/PricingManager/Rule/Listing/Dao.php
@@ -32,7 +32,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
 
         // load objects
         $ruleIds = $this->db->fetchFirstColumn(
-            'SELECT id FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), 
+            'SELECT id FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
             $this->model->getConditionVariables(),
         );
 

--- a/src/PricingManager/Rule/Listing/Dao.php
+++ b/src/PricingManager/Rule/Listing/Dao.php
@@ -32,7 +32,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
 
         // load objects
         $ruleIds = $this->db->fetchFirstColumn('SELECT id FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME .
-                                                 $this->getCondition() . $this->getOrder() . $this->getOffsetLimit());
+                                                 $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
 
         foreach ($ruleIds as $id) {
             $rules[] = call_user_func([$this->getRuleClass(), 'getById'], $id);
@@ -56,7 +56,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME . '`' . $this->getCondition());
+            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME . '`' . $this->getCondition(), $this->model->getConditionVariables());
         } catch (\Exception $e) {
             return 0;
         }

--- a/src/PricingManager/Rule/Listing/Dao.php
+++ b/src/PricingManager/Rule/Listing/Dao.php
@@ -32,7 +32,8 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
 
         // load objects
         $ruleIds = $this->db->fetchFirstColumn(
-            'SELECT id FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
+            'SELECT id FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME
+            . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
             $this->model->getConditionVariables(),
         );
 
@@ -59,7 +60,8 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne(
-                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME . '`' . $this->getCondition(),
+                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME . '`'
+                . $this->getCondition(),
                 $this->model->getConditionVariables(),
             );
         } catch (\Exception $e) {

--- a/src/PricingManager/Rule/Listing/Dao.php
+++ b/src/PricingManager/Rule/Listing/Dao.php
@@ -32,7 +32,8 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
 
         // load objects
         $ruleIds = $this->db->fetchFirstColumn(
-            'SELECT id FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME
+            'SELECT id FROM '
+            . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME
             . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
             $this->model->getConditionVariables(),
         );
@@ -60,8 +61,9 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     {
         try {
             return (int) $this->db->fetchOne(
-                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME . '`'
-                . $this->getCondition(),
+                'SELECT COUNT(*) FROM `'
+                . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME
+                . '`' . $this->getCondition(),
                 $this->model->getConditionVariables(),
             );
         } catch (\Exception $e) {

--- a/src/PricingManager/Rule/Listing/Dao.php
+++ b/src/PricingManager/Rule/Listing/Dao.php
@@ -31,8 +31,10 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
         $rules = [];
 
         // load objects
-        $ruleIds = $this->db->fetchFirstColumn('SELECT id FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME .
-                                                 $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), $this->model->getConditionVariables());
+        $ruleIds = $this->db->fetchFirstColumn(
+            'SELECT id FROM ' . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(), 
+            $this->model->getConditionVariables(),
+        );
 
         foreach ($ruleIds as $id) {
             $rules[] = call_user_func([$this->getRuleClass(), 'getById'], $id);
@@ -56,7 +58,10 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
     public function getTotalCount(): int
     {
         try {
-            return (int) $this->db->fetchOne('SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME . '`' . $this->getCondition(), $this->model->getConditionVariables());
+            return (int) $this->db->fetchOne(
+                'SELECT COUNT(*) FROM `' . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME . '`' . $this->getCondition(),
+                $this->model->getConditionVariables(),
+            );
         } catch (\Exception $e) {
             return 0;
         }


### PR DESCRIPTION
When the call is missing, you get an error when doing calls like `$list->setCondition('userid = ? AND name = ?', [$userId, $name]);` because the values in the second parameter are ignored.

`Pimcore\Bundle\EcommerceFrameworkBundle\VoucherService\Token\Listing\Dao` is the only one where it's not missing.