### PR TITLE
Fixed handling of multiselect values in classificationstore

### DIFF
--- a/src/IndexService/Interpreter/DefaultClassificationStore.php
+++ b/src/IndexService/Interpreter/DefaultClassificationStore.php
@@ -46,7 +46,7 @@ class DefaultClassificationStore implements InterpreterInterface
 
                 // Ensure that we store all values as array of strings
                 $keyValues = is_array($keyValue) ? $keyValue : [$keyValue];
-                $data['values'][$keyId] = array_map(fn($val) => (string) $val, $keyValues);
+                $data['values'][$keyId] = array_map(fn ($val) => (string) $val, $keyValues);
                 $data['keys'][$keyId] = $keyId;
             }
         }

--- a/src/IndexService/Interpreter/DefaultClassificationStore.php
+++ b/src/IndexService/Interpreter/DefaultClassificationStore.php
@@ -41,7 +41,12 @@ class DefaultClassificationStore implements InterpreterInterface
                 if (!isset($data['values'][$keyId])) {
                     $data['values'][$keyId] = [];
                 }
-                $data['values'][$keyId][] = (string) $value->getLocalizedKeyValue($groupId, $keyId, 'en');
+
+                $keyValue = $value->getLocalizedKeyValue($groupId, $keyId, 'en');
+
+                // Ensure that we store all values as array of strings
+                $keyValues = is_array($keyValue) ? $keyValue : [$keyValue];
+                $data['values'][$keyId] = array_map(fn($val) => (string) $val, $keyValues);
                 $data['keys'][$keyId] = $keyId;
             }
         }


### PR DESCRIPTION
Multiselect values are being returned as arrays, therefore the cast to string fails and throws an exception.

Background:
Until now, each value of a classificationstore keyconfig is being stored as array of strings (with just one possible value in the array). E.g. 
```
    "classificationStoreName": {
      "values": {
        "1": [
          "test_value"
        ],
        "4": [
          "another_test_value"
        ],
```

With this change, the index will now have multiple values, when multiple select elements were selected.

```
    "classificationStoreName": {
      "values": {
        "1": [
          "test_value"
        ],
        "4": [
          "another_test_value",
          "yet_another_test_value"
        ],
```