### PR TITLE
Allow `CartPriceModificatorInterface::modify()` to return `null`

### DIFF
--- a/src/CartManager/CartPriceModificator/CartPriceModificatorInterface.php
+++ b/src/CartManager/CartPriceModificator/CartPriceModificatorInterface.php
@@ -31,5 +31,5 @@ interface CartPriceModificatorInterface
      * @param CartInterface $cart - cart
      *
      */
-    public function modify(PriceInterface $currentSubTotal, CartInterface $cart): ModificatedPriceInterface;
+    public function modify(PriceInterface $currentSubTotal, CartInterface $cart): ?ModificatedPriceInterface;
 }


### PR DESCRIPTION
Fixes #265 