### PR TITLE
Allow `string` IDs in `SessionCart::getById()`

### DIFF
--- a/src/CartManager/SessionCart.php
+++ b/src/CartManager/SessionCart.php
@@ -101,7 +101,7 @@ class SessionCart extends AbstractCart implements CartInterface
         return $this;
     }
 
-    public static function getById(int $id): ?SessionCart
+    public static function getById(int|string $id): ?SessionCart
     {
         $carts = static::getAllCartsForUser(-1);
 


### PR DESCRIPTION
I'm not sure if we should change the interface as well. The getters and setters also allow `string`, but the database cart only allows `int`, so we would have to check that nobody passes a string there.

Resolves #267