### PR TITLE
Add getRealFieldname to AbstractElasticsearch

### DIFF
--- a/src/FilterService/FilterType/AbstractFilterType.php
+++ b/src/FilterService/FilterType/AbstractFilterType.php
@@ -159,4 +159,17 @@ abstract class AbstractFilterType
     {
         return $this->templatingEngine->render($template, $parameters);
     }
+
+    /**
+     * Returns fieldname without precondition prefix.
+     */
+    public static function getRealFieldname(string $fieldname): string
+    {
+        $isPrecondition = str_starts_with($fieldname, self::PREFIX_PRECONDITION);
+        if ($isPrecondition) {
+            return substr($fieldname, strlen(self::PREFIX_PRECONDITION));
+        }
+
+        return $fieldname;
+    }
 }

--- a/src/IndexService/ProductList/DefaultMysql.php
+++ b/src/IndexService/ProductList/DefaultMysql.php
@@ -101,7 +101,7 @@ class DefaultMysql implements ProductListInterface
 
     public function addRelationCondition(string $fieldname, string|array $condition): void
     {
-        $realFieldname = $this->getRealFieldname($fieldname);
+        $realFieldname = AbstractFilterType::getRealFieldname($fieldname);
         $fieldnameCondition = '`fieldname` = ' . $this->quote($realFieldname);
 
         $this->products = null;
@@ -279,19 +279,6 @@ class DefaultMysql implements ProductListInterface
         }
 
         return $this->products;
-    }
-
-    /**
-     * Returns fieldname without precondition prefix.
-     */
-    protected function getRealFieldname(string $fieldname): string
-    {
-        $isPrecondition = str_starts_with($fieldname, AbstractFilterType::PREFIX_PRECONDITION);
-        if ($isPrecondition) {
-            return substr($fieldname, strlen(AbstractFilterType::PREFIX_PRECONDITION));
-        }
-
-        return $fieldname;
     }
 
     /**

--- a/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\ProductList\Elast
 use Elastic\Elasticsearch\Client;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Exception\InvalidConfigException;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Factory;
+use Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\FilterType\AbstractFilterType;
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\ElasticSearch;
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\SearchConfigInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\ProductList\ProductListInterface;
@@ -165,6 +166,7 @@ abstract class AbstractElasticSearch implements ProductListInterface, TenantConf
      */
     public function addCondition(array|string|bool $condition, string $fieldname = ''): void
     {
+        $fieldname = $this->getRealFieldname($fieldname);
         $this->filterConditions[$fieldname][] = $condition;
         $this->preparedGroupByValuesLoaded = false;
         $this->products = null;
@@ -187,6 +189,7 @@ abstract class AbstractElasticSearch implements ProductListInterface, TenantConf
      */
     public function addRelationCondition(string $fieldname, string|array $condition): void
     {
+        $fieldname = $this->getRealFieldname($fieldname);
         $this->relationConditions[$fieldname][] = $condition;
         $this->preparedGroupByValuesLoaded = false;
         $this->products = null;
@@ -1236,5 +1239,18 @@ abstract class AbstractElasticSearch implements ProductListInterface, TenantConf
         }
 
         return 0.0;
+    }
+
+    /**
+     * Returns fieldname without precondition prefix.
+     */
+    protected function getRealFieldname(string $fieldname): string
+    {
+        $isPrecondition = str_starts_with($fieldname, AbstractFilterType::PREFIX_PRECONDITION);
+        if ($isPrecondition) {
+            return substr($fieldname, strlen(AbstractFilterType::PREFIX_PRECONDITION));
+        }
+
+        return $fieldname;
     }
 }

--- a/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -166,7 +166,7 @@ abstract class AbstractElasticSearch implements ProductListInterface, TenantConf
      */
     public function addCondition(array|string|bool $condition, string $fieldname = ''): void
     {
-        $fieldname = $this->getRealFieldname($fieldname);
+        $fieldname = AbstractFilterType::getRealFieldname($fieldname);
         $this->filterConditions[$fieldname][] = $condition;
         $this->preparedGroupByValuesLoaded = false;
         $this->products = null;
@@ -189,7 +189,7 @@ abstract class AbstractElasticSearch implements ProductListInterface, TenantConf
      */
     public function addRelationCondition(string $fieldname, string|array $condition): void
     {
-        $fieldname = $this->getRealFieldname($fieldname);
+        $fieldname = AbstractFilterType::getRealFieldname($fieldname);
         $this->relationConditions[$fieldname][] = $condition;
         $this->preparedGroupByValuesLoaded = false;
         $this->products = null;
@@ -1239,18 +1239,5 @@ abstract class AbstractElasticSearch implements ProductListInterface, TenantConf
         }
 
         return 0.0;
-    }
-
-    /**
-     * Returns fieldname without precondition prefix.
-     */
-    protected function getRealFieldname(string $fieldname): string
-    {
-        $isPrecondition = str_starts_with($fieldname, AbstractFilterType::PREFIX_PRECONDITION);
-        if ($isPrecondition) {
-            return substr($fieldname, strlen(AbstractFilterType::PREFIX_PRECONDITION));
-        }
-
-        return $fieldname;
     }
 }

--- a/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -166,7 +166,6 @@ abstract class AbstractElasticSearch implements ProductListInterface, TenantConf
      */
     public function addCondition(array|string|bool $condition, string $fieldname = ''): void
     {
-        $fieldname = AbstractFilterType::getRealFieldname($fieldname);
         $this->filterConditions[$fieldname][] = $condition;
         $this->preparedGroupByValuesLoaded = false;
         $this->products = null;
@@ -189,7 +188,6 @@ abstract class AbstractElasticSearch implements ProductListInterface, TenantConf
      */
     public function addRelationCondition(string $fieldname, string|array $condition): void
     {
-        $fieldname = AbstractFilterType::getRealFieldname($fieldname);
         $this->relationConditions[$fieldname][] = $condition;
         $this->preparedGroupByValuesLoaded = false;
         $this->products = null;
@@ -638,11 +636,12 @@ abstract class AbstractElasticSearch implements ProductListInterface, TenantConf
     {
         foreach ($this->relationConditions as $fieldname => $relationConditionArray) {
             if (!array_key_exists($fieldname, $excludedFieldnames)) {
+                $realFieldname = AbstractFilterType::getRealFieldname($fieldname);
                 foreach ($relationConditionArray as $relationCondition) {
                     if (is_array($relationCondition)) {
                         $boolFilters[] = $relationCondition;
                     } else {
-                        $boolFilters[] = ['term' => [$this->tenantConfig->getFieldNameMapped($fieldname) => $relationCondition]];
+                        $boolFilters[] = ['term' => [$this->tenantConfig->getFieldNameMapped($realFieldname) => $relationCondition]];
                     }
                 }
             }
@@ -660,11 +659,12 @@ abstract class AbstractElasticSearch implements ProductListInterface, TenantConf
     {
         foreach ($this->filterConditions as $fieldname => $filterConditionArray) {
             if (!array_key_exists($fieldname, $excludedFieldnames)) {
+                $realFieldname = AbstractFilterType::getRealFieldname($fieldname);
                 foreach ($filterConditionArray as $filterCondition) {
                     if (is_array($filterCondition)) {
                         $boolFilters[] = $filterCondition;
                     } else {
-                        $boolFilters[] = ['term' => [$this->tenantConfig->getFieldNameMapped($fieldname, true) => $filterCondition]];
+                        $boolFilters[] = ['term' => [$this->tenantConfig->getFieldNameMapped($realFieldname, true) => $filterCondition]];
                     }
                 }
             }

--- a/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -642,7 +642,7 @@ abstract class AbstractElasticSearch implements ProductListInterface, TenantConf
                         $boolFilters[] = $relationCondition;
                     } else {
                         $boolFilters[] = ['term' => [
-                            $this->tenantConfig->getFieldNameMapped($realFieldname) => $relationCondition]
+                            $this->tenantConfig->getFieldNameMapped($realFieldname) => $relationCondition],
                         ];
                     }
                 }
@@ -667,7 +667,7 @@ abstract class AbstractElasticSearch implements ProductListInterface, TenantConf
                         $boolFilters[] = $filterCondition;
                     } else {
                         $boolFilters[] = ['term' => [
-                            $this->tenantConfig->getFieldNameMapped($realFieldname, true) => $filterCondition]
+                            $this->tenantConfig->getFieldNameMapped($realFieldname, true) => $filterCondition],
                         ];
                     }
                 }

--- a/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
+++ b/src/IndexService/ProductList/ElasticSearch/AbstractElasticSearch.php
@@ -641,7 +641,9 @@ abstract class AbstractElasticSearch implements ProductListInterface, TenantConf
                     if (is_array($relationCondition)) {
                         $boolFilters[] = $relationCondition;
                     } else {
-                        $boolFilters[] = ['term' => [$this->tenantConfig->getFieldNameMapped($realFieldname) => $relationCondition]];
+                        $boolFilters[] = ['term' => [
+                            $this->tenantConfig->getFieldNameMapped($realFieldname) => $relationCondition]
+                        ];
                     }
                 }
             }
@@ -664,7 +666,9 @@ abstract class AbstractElasticSearch implements ProductListInterface, TenantConf
                     if (is_array($filterCondition)) {
                         $boolFilters[] = $filterCondition;
                     } else {
-                        $boolFilters[] = ['term' => [$this->tenantConfig->getFieldNameMapped($realFieldname, true) => $filterCondition]];
+                        $boolFilters[] = ['term' => [
+                            $this->tenantConfig->getFieldNameMapped($realFieldname, true) => $filterCondition]
+                        ];
                     }
                 }
             }

--- a/src/IndexService/ProductList/OpenSearch/AbstractOpenSearch.php
+++ b/src/IndexService/ProductList/OpenSearch/AbstractOpenSearch.php
@@ -167,7 +167,6 @@ abstract class AbstractOpenSearch implements ProductListInterface, TenantConfigI
      */
     public function addCondition(array|string|bool $condition, string $fieldname = ''): void
     {
-        $fieldname = AbstractFilterType::getRealFieldname($fieldname);
         $this->filterConditions[$fieldname][] = $condition;
         $this->preparedGroupByValuesLoaded = false;
         $this->products = null;
@@ -639,11 +638,12 @@ abstract class AbstractOpenSearch implements ProductListInterface, TenantConfigI
     {
         foreach ($this->relationConditions as $fieldname => $relationConditionArray) {
             if (!array_key_exists($fieldname, $excludedFieldnames)) {
+                $realFieldname = AbstractFilterType::getRealFieldname($fieldname);
                 foreach ($relationConditionArray as $relationCondition) {
                     if (is_array($relationCondition)) {
                         $boolFilters[] = $relationCondition;
                     } else {
-                        $boolFilters[] = ['term' => [$this->tenantConfig->getFieldNameMapped($fieldname) => $relationCondition]];
+                        $boolFilters[] = ['term' => [$this->tenantConfig->getFieldNameMapped($realFieldname) => $relationCondition]];
                     }
                 }
             }
@@ -661,11 +661,12 @@ abstract class AbstractOpenSearch implements ProductListInterface, TenantConfigI
     {
         foreach ($this->filterConditions as $fieldname => $filterConditionArray) {
             if (!array_key_exists($fieldname, $excludedFieldnames)) {
+                $realFieldname = AbstractFilterType::getRealFieldname($fieldname);
                 foreach ($filterConditionArray as $filterCondition) {
                     if (is_array($filterCondition)) {
                         $boolFilters[] = $filterCondition;
                     } else {
-                        $boolFilters[] = ['term' => [$this->tenantConfig->getFieldNameMapped($fieldname, true) => $filterCondition]];
+                        $boolFilters[] = ['term' => [$this->tenantConfig->getFieldNameMapped($realFieldname, true) => $filterCondition]];
                     }
                 }
             }

--- a/src/IndexService/ProductList/OpenSearch/AbstractOpenSearch.php
+++ b/src/IndexService/ProductList/OpenSearch/AbstractOpenSearch.php
@@ -16,6 +16,7 @@ namespace Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\ProductList\OpenS
 use OpenSearch\Client;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Exception\InvalidConfigException;
 use Pimcore\Bundle\EcommerceFrameworkBundle\Factory;
+use Pimcore\Bundle\EcommerceFrameworkBundle\FilterService\FilterType\AbstractFilterType;
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\OpenSearch;
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\Config\SearchConfigInterface;
 use Pimcore\Bundle\EcommerceFrameworkBundle\IndexService\ProductList\ProductListInterface;
@@ -166,6 +167,7 @@ abstract class AbstractOpenSearch implements ProductListInterface, TenantConfigI
      */
     public function addCondition(array|string|bool $condition, string $fieldname = ''): void
     {
+        $fieldname = AbstractFilterType::getRealFieldname($fieldname);
         $this->filterConditions[$fieldname][] = $condition;
         $this->preparedGroupByValuesLoaded = false;
         $this->products = null;
@@ -188,6 +190,7 @@ abstract class AbstractOpenSearch implements ProductListInterface, TenantConfigI
      */
     public function addRelationCondition(string $fieldname, string|array $condition): void
     {
+        $fieldname = AbstractFilterType::getRealFieldname($fieldname);
         $this->relationConditions[$fieldname][] = $condition;
         $this->preparedGroupByValuesLoaded = false;
         $this->products = null;

--- a/src/IndexService/ProductList/OpenSearch/AbstractOpenSearch.php
+++ b/src/IndexService/ProductList/OpenSearch/AbstractOpenSearch.php
@@ -189,7 +189,6 @@ abstract class AbstractOpenSearch implements ProductListInterface, TenantConfigI
      */
     public function addRelationCondition(string $fieldname, string|array $condition): void
     {
-        $fieldname = AbstractFilterType::getRealFieldname($fieldname);
         $this->relationConditions[$fieldname][] = $condition;
         $this->preparedGroupByValuesLoaded = false;
         $this->products = null;

--- a/src/IndexService/ProductList/OpenSearch/AbstractOpenSearch.php
+++ b/src/IndexService/ProductList/OpenSearch/AbstractOpenSearch.php
@@ -642,7 +642,9 @@ abstract class AbstractOpenSearch implements ProductListInterface, TenantConfigI
                     if (is_array($relationCondition)) {
                         $boolFilters[] = $relationCondition;
                     } else {
-                        $boolFilters[] = ['term' => [$this->tenantConfig->getFieldNameMapped($realFieldname) => $relationCondition]];
+                        $boolFilters[] = ['term' => [
+                            $this->tenantConfig->getFieldNameMapped($realFieldname) => $relationCondition]
+                        ];
                     }
                 }
             }
@@ -665,7 +667,9 @@ abstract class AbstractOpenSearch implements ProductListInterface, TenantConfigI
                     if (is_array($filterCondition)) {
                         $boolFilters[] = $filterCondition;
                     } else {
-                        $boolFilters[] = ['term' => [$this->tenantConfig->getFieldNameMapped($realFieldname, true) => $filterCondition]];
+                        $boolFilters[] = ['term' => [
+                            $this->tenantConfig->getFieldNameMapped($realFieldname, true) => $filterCondition]
+                        ];
                     }
                 }
             }

--- a/src/IndexService/ProductList/OpenSearch/AbstractOpenSearch.php
+++ b/src/IndexService/ProductList/OpenSearch/AbstractOpenSearch.php
@@ -643,7 +643,7 @@ abstract class AbstractOpenSearch implements ProductListInterface, TenantConfigI
                         $boolFilters[] = $relationCondition;
                     } else {
                         $boolFilters[] = ['term' => [
-                            $this->tenantConfig->getFieldNameMapped($realFieldname) => $relationCondition]
+                            $this->tenantConfig->getFieldNameMapped($realFieldname) => $relationCondition],
                         ];
                     }
                 }
@@ -668,7 +668,7 @@ abstract class AbstractOpenSearch implements ProductListInterface, TenantConfigI
                         $boolFilters[] = $filterCondition;
                     } else {
                         $boolFilters[] = ['term' => [
-                            $this->tenantConfig->getFieldNameMapped($realFieldname, true) => $filterCondition]
+                            $this->tenantConfig->getFieldNameMapped($realFieldname, true) => $filterCondition],
                         ];
                     }
                 }


### PR DESCRIPTION
When testing this with Elasticsearch we have the same problem as [here](https://github.com/pimcore/ecommerce-framework-bundle/pull/249#discussion_r2115407851).

So the query is built as below for FilterRelation and FilterSelect:

```
            
              "term": {
                "PRECONDITION_companies": "11111"
              }
            
```

It seems the removal of the `PRECONDITION_` prefix was only added for MySQL?