### PR TITLE
[Bug] Fix currency formatting for zero values

### DIFF
--- a/src/Model/Currency.php
+++ b/src/Model/Currency.php
@@ -73,7 +73,7 @@ class Currency
 
     public function toCurrency(null|float|int|string|Decimal $value, array|string $pattern = 'default'): string
     {
-        if ($value == null) {
+        if ($value === null) {
             return '';
         }
 


### PR DESCRIPTION
There's an issue with zero (`int|float|string`) values because they are treated as `NULL` values. In result, nothing is output.
The expected behavior is that the `Currency::toCurrency()` method outputs formatted currency string (e.g. `€0.00`) for zero values.