### PR TITLE
[Bugfix]: Ensure `getConditionVariableTypes()` is used in all DAOs

### DIFF
--- a/src/CartManager/Cart/Listing/Dao.php
+++ b/src/CartManager/Cart/Listing/Dao.php
@@ -32,6 +32,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
             . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME
             . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
             $this->model->getConditionVariables(),
+            $this->model->getConditionVariableTypes(),
         );
 
         foreach ($cartIds as $id) {
@@ -51,6 +52,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
                 . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\Cart\Dao::TABLE_NAME
                 . '`' . $this->getCondition(),
                 $this->model->getConditionVariables(),
+                $this->model->getConditionVariableTypes(),
             );
         } catch (\Exception $e) {
             return 0;

--- a/src/CartManager/CartCheckoutData/Listing/Dao.php
+++ b/src/CartManager/CartCheckoutData/Listing/Dao.php
@@ -33,6 +33,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
             . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME
             . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
             $this->model->getConditionVariables(),
+            $this->model->getConditionVariableTypes(),
         );
 
         foreach ($cartCheckoutDataItems as $item) {
@@ -51,6 +52,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
                 . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartCheckoutData\Dao::TABLE_NAME
                 . '`' . $this->getCondition(),
                 $this->model->getConditionVariables(),
+                $this->model->getConditionVariableTypes(),
             );
         } catch (\Exception $e) {
             return 0;

--- a/src/CartManager/CartItem/Listing/Dao.php
+++ b/src/CartManager/CartItem/Listing/Dao.php
@@ -32,6 +32,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
             . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME
             . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
             $this->model->getConditionVariables(),
+            $this->model->getConditionVariableTypes(),
         );
 
         foreach ($cartItems as $item) {
@@ -50,6 +51,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
                 . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME
                 . '`' . $this->getCondition(),
                 $this->model->getConditionVariables(),
+                $this->model->getConditionVariableTypes(),
             );
         } catch (\Exception $e) {
             return 0;
@@ -63,6 +65,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
             . \Pimcore\Bundle\EcommerceFrameworkBundle\CartManager\CartItem\Dao::TABLE_NAME
             . '`' . $this->getCondition(),
             $this->model->getConditionVariables(),
+            $this->model->getConditionVariableTypes(),
         );
     }
 

--- a/src/PricingManager/Rule/Listing/Dao.php
+++ b/src/PricingManager/Rule/Listing/Dao.php
@@ -36,6 +36,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
             . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME
             . $this->getCondition() . $this->getOrder() . $this->getOffsetLimit(),
             $this->model->getConditionVariables(),
+            $this->model->getConditionVariableTypes(),
         );
 
         foreach ($ruleIds as $id) {
@@ -65,6 +66,7 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
                 . \Pimcore\Bundle\EcommerceFrameworkBundle\PricingManager\Rule\Dao::TABLE_NAME
                 . '`' . $this->getCondition(),
                 $this->model->getConditionVariables(),
+                $this->model->getConditionVariableTypes(),
             );
         } catch (\Exception $e) {
             return 0;

--- a/src/VoucherService/Token/Listing/Dao.php
+++ b/src/VoucherService/Token/Listing/Dao.php
@@ -32,8 +32,8 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
             \Pimcore\Bundle\EcommerceFrameworkBundle\VoucherService\Token\Dao::TABLE_NAME .
               $this->getCondition() .
               $this->getOrder() .
-              $this->getOffsetLimit(), 
-            $this->model->getConditionVariables(), 
+              $this->getOffsetLimit(),
+            $this->model->getConditionVariables(),
             $this->model->getConditionVariableTypes());
 
         foreach ($unitIds as $row) {

--- a/src/VoucherService/Token/Listing/Dao.php
+++ b/src/VoucherService/Token/Listing/Dao.php
@@ -52,7 +52,8 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
                 'SELECT COUNT(*) as amount FROM ' .
                 \Pimcore\Bundle\EcommerceFrameworkBundle\VoucherService\Token\Dao::TABLE_NAME .
                 $this->getCondition(),
-                $this->model->getConditionVariables()
+                $this->model->getConditionVariables(),
+                $this->model->getConditionVariableTypes(),
             );
         } catch (\Exception $e) {
             return 0;

--- a/src/VoucherService/Token/Listing/Dao.php
+++ b/src/VoucherService/Token/Listing/Dao.php
@@ -34,7 +34,8 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
               $this->getOrder() .
               $this->getOffsetLimit(),
             $this->model->getConditionVariables(),
-            $this->model->getConditionVariableTypes());
+            $this->model->getConditionVariableTypes()
+        );
 
         foreach ($unitIds as $row) {
             $item = new \Pimcore\Bundle\EcommerceFrameworkBundle\VoucherService\Token();

--- a/src/VoucherService/Token/Listing/Dao.php
+++ b/src/VoucherService/Token/Listing/Dao.php
@@ -30,9 +30,11 @@ class Dao extends \Pimcore\Model\Listing\Dao\AbstractDao
 
         $unitIds = $this->db->fetchAllAssociative('SELECT * FROM ' .
             \Pimcore\Bundle\EcommerceFrameworkBundle\VoucherService\Token\Dao::TABLE_NAME .
-            $this->getCondition() .
-            $this->getOrder() .
-            $this->getOffsetLimit(), $this->model->getConditionVariables());
+              $this->getCondition() .
+              $this->getOrder() .
+              $this->getOffsetLimit(), 
+            $this->model->getConditionVariables(), 
+            $this->model->getConditionVariableTypes());
 
         foreach ($unitIds as $row) {
             $item = new \Pimcore\Bundle\EcommerceFrameworkBundle\VoucherService\Token();


### PR DESCRIPTION
Passes the types to all queries in all DAOs.
This is necessary for advanced queries, e.g., with IN(?).
Doctrine needs the types in this case.

This is kind of a follow-up of #258.
There is a similar PR in pimcore/pimcore#18789