### PR TITLE
Fix deprecation of `EsSyncCommand`

### DIFF
--- a/src/Command/IndexService/EsSyncCommand.php
+++ b/src/Command/IndexService/EsSyncCommand.php
@@ -35,13 +35,6 @@ class EsSyncCommand extends AbstractIndexServiceCommand
     {
         parent::configure();
 
-        trigger_deprecation(
-            'pimcore/ecommerce-framework-bundle',
-            '2.0.0',
-            'The command "%s" is deprecated and will be removed in a future version. Please use the ecommerce:indexservice:search-index-sync instead.',
-            $this->getName()
-        );
-
         $this
             ->setName('ecommerce:indexservice:elasticsearch-sync')
             ->setDescription(
@@ -60,6 +53,13 @@ class EsSyncCommand extends AbstractIndexServiceCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        trigger_deprecation(
+            'pimcore/ecommerce-framework-bundle',
+            '2.0.0',
+            'The command "%s" is deprecated and will be removed in a future version. Please use the ecommerce:indexservice:search-index-sync instead.',
+            $this->getName()
+        );
+        
         $mode = $input->getArgument('mode');
         $tenantName = $input->getOption('tenant');
 

--- a/src/Command/IndexService/EsSyncCommand.php
+++ b/src/Command/IndexService/EsSyncCommand.php
@@ -55,7 +55,7 @@ class EsSyncCommand extends AbstractIndexServiceCommand
     {
         trigger_deprecation(
             'pimcore/ecommerce-framework-bundle',
-            '2.0.0',
+            '1.3',
             'The command "%s" is deprecated and will be removed in a future version. Please use the ecommerce:indexservice:search-index-sync instead.',
             $this->getName()
         );


### PR DESCRIPTION
The deprecation was triggered `before` the command's name was set, so its message was:

> User Deprecated: Since pimcore/ecommerce-framework-bundle 2.0.0: The command "" is deprecated and will be removed in a future version. Please use the ecommerce:indexservice:search-index-sync instead.

So the version was wrong, and the command name was empty. Also, the deprecation gets triggered even if it is not executed, because the `configure()` method get called by Symfony when the command is registered.